### PR TITLE
Demo iOS app - Get election manifest from API

### DIFF
--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo.xcodeproj/project.pbxproj
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A52A8FDE24F01A2B0017244F /* ContestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52A8FDD24F01A2B0017244F /* ContestViewController.swift */; };
 		A54A05F724F8312300B9CFE2 /* ProgressHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54A05F624F8312300B9CFE2 /* ProgressHUD.swift */; };
 		A54A05F924FE98C300B9CFE2 /* CiphertextElectionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54A05F824FE98C300B9CFE2 /* CiphertextElectionContext.swift */; };
+		A54A60E92502CCC40040F44A /* HttpDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54A60E82502CCC40040F44A /* HttpDataService.swift */; };
 		A56C8C5A24EF14B80044EA70 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56C8C5924EF14B80044EA70 /* AppDelegate.swift */; };
 		A56C8C5C24EF14B80044EA70 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56C8C5B24EF14B80044EA70 /* SceneDelegate.swift */; };
 		A56C8C5E24EF14B80044EA70 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56C8C5D24EF14B80044EA70 /* MainViewController.swift */; };
@@ -34,6 +35,7 @@
 		A5DD4B3224F6D69400B9B176 /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DD4B3124F6D69400B9B176 /* ReviewViewController.swift */; };
 		A5DD4B3424F7EE1000B9B176 /* UIViewController+alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DD4B3324F7EE1000B9B176 /* UIViewController+alert.swift */; };
 		A5E778292502A57E0049D6D6 /* FinishedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E778282502A57E0049D6D6 /* FinishedViewController.swift */; };
+		A5F5972C2503D246009CFE8A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F5972B2503D246009CFE8A /* Constants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,7 @@
 		A52A8FDD24F01A2B0017244F /* ContestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContestViewController.swift; sourceTree = "<group>"; };
 		A54A05F624F8312300B9CFE2 /* ProgressHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHUD.swift; sourceTree = "<group>"; };
 		A54A05F824FE98C300B9CFE2 /* CiphertextElectionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CiphertextElectionContext.swift; sourceTree = "<group>"; };
+		A54A60E82502CCC40040F44A /* HttpDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpDataService.swift; sourceTree = "<group>"; };
 		A54E62A4250024230007BA4C /* hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hash.h; path = ../../../../../include/electionguard/hash.h; sourceTree = "<group>"; };
 		A56C8C5624EF14B80044EA70 /* ElectionGuard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ElectionGuard.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A56C8C5924EF14B80044EA70 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -73,6 +76,7 @@
 		A5DD4B3124F6D69400B9B176 /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
 		A5DD4B3324F7EE1000B9B176 /* UIViewController+alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+alert.swift"; sourceTree = "<group>"; };
 		A5E778282502A57E0049D6D6 /* FinishedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedViewController.swift; sourceTree = "<group>"; };
+		A5F5972B2503D246009CFE8A /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		B12245AD25001CB300416B56 /* tracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tracker.h; path = ../../../../../include/electionguard/tracker.h; sourceTree = "<group>"; };
 		B160683B24F7F4B400EA2A14 /* constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = constants.h; path = ../../../../../include/electionguard/constants.h; sourceTree = "<group>"; };
 		B160683C24F7F4B400EA2A14 /* election.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = election.h; path = ../../../../../include/electionguard/election.h; sourceTree = "<group>"; };
@@ -147,6 +151,7 @@
 				A5A800A324F044EA0068FE96 /* Models */,
 				A5A8009B24F027290068FE96 /* Views */,
 				A52A8FDC24F019C60017244F /* ViewControllers */,
+				A5F5972B2503D246009CFE8A /* Constants.swift */,
 			);
 			path = ElectionGuardDemo;
 			sourceTree = "<group>";
@@ -197,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				A5A800A124F044940068FE96 /* EGDataService.swift */,
+				A54A60E82502CCC40040F44A /* HttpDataService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -295,9 +301,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5F5972C2503D246009CFE8A /* Constants.swift in Sources */,
 				A5DD4B3424F7EE1000B9B176 /* UIViewController+alert.swift in Sources */,
 				A5A8009A24F01F0C0068FE96 /* UIView+addSubviews.swift in Sources */,
 				A5A8009F24F032DE0068FE96 /* EGButton.swift in Sources */,
+				A54A60E92502CCC40040F44A /* HttpDataService.swift in Sources */,
 				A5A8009D24F027410068FE96 /* SelectionCollectionViewCell.swift in Sources */,
 				A5A800B124F045220068FE96 /* Candidate.swift in Sources */,
 				A56C8C7E24EF1CA70044EA70 /* ElectionGuard.swift in Sources */,

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Constants.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Constants.swift
@@ -1,0 +1,13 @@
+//
+//  Constants.swift
+//  ElectionGuardDemo
+//
+//  Created by Ed Snider on 9/5/20.
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+import Foundation
+
+struct Constants {
+    static let BaseApiUrl = "http://127.0.0.1:8000/api/v1"
+}

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Models/ContestDescription.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Models/ContestDescription.swift
@@ -58,20 +58,20 @@ enum ContestType: String, Codable {
     case referendum = "ReferendumContest"
 }
 
-enum VoteVariationType: String, Codable {
-    case unknown
-    case one_of_m
-    case approval
-    case borda
-    case cumulative
-    case majority
-    case n_of_m
-    case plurality
-    case proportional
-    case range
-    case rcv
-    case super_majority
-    case other
+enum VoteVariationType: Int, Codable {
+    case unknown = 0
+    case one_of_m = 1
+    case approval = 2
+    case borda = 3
+    case cumulative = 4
+    case majority = 5
+    case n_of_m = 6
+    case plurality = 7
+    case proportional = 8
+    case range = 9
+    case rcv = 10
+    case super_majority = 11
+    case other = 12
 }
 
 
@@ -111,7 +111,7 @@ extension ContestDescription {
         toHash += "|"
         toHash += self.electoralDistrictId ?? "null"
         toHash += "|"
-        toHash += self.voteVariation?.rawValue ?? "null" // TODO: Confirm this is correct
+        toHash += self.voteVariation != nil ? String(self.voteVariation!.rawValue) : "null" // TODO: Confirm this is correct
         toHash += "|"
         
         if let titleLanguages = self.ballotTitle?.text {

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Models/ElectionDescription.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Models/ElectionDescription.swift
@@ -50,13 +50,13 @@ struct ElectionDescription: Codable {
     }
 }
 
-enum ElectionType: String, Codable {
-    case unknown
-    case general
-    case partisan_primary_closed
-    case partisan_primary_open
-    case primary
-    case runoff
-    case special
-    case other
+enum ElectionType: Int, Codable {
+    case unknown = 0
+    case general = 1
+    case partisan_primary_closed = 2
+    case partisan_primary_open = 3
+    case primary = 4
+    case runoff = 5
+    case special = 6
+    case other = 7
 }

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Models/GeopoliticalUnit.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Models/GeopoliticalUnit.swift
@@ -20,34 +20,34 @@ struct GeopoliticalUnit: Codable {
     }
 }
 
-enum ReportingUnitType: String, Codable {
-    case unknown
-    case ballot_batch
-    case ballot_style_area
-    case borough
-    case city
-    case city_council
-    case combined_precinct
-    case congressional
-    case country
-    case county
-    case county_council
-    case drop_box
-    case judicial
-    case municipality
-    case polling_place
-    case precinct
-    case school
-    case special
-    case split_precinct
-    case state
-    case state_house
-    case state_senate
-    case township
-    case utility
-    case village
-    case vote_center
-    case ward
-    case water
-    case other
+enum ReportingUnitType: Int, Codable {
+    case unknown = 0
+    case ballot_batch = 1
+    case ballot_style_area = 2
+    case borough = 3
+    case city = 4
+    case city_council = 5
+    case combined_precinct = 6
+    case congressional = 7
+    case country = 8
+    case county = 9
+    case county_council = 10
+    case drop_box = 11
+    case judicial = 12
+    case municipality = 13
+    case polling_place = 14
+    case precinct = 15
+    case school = 16
+    case special = 17
+    case split_precinct = 18
+    case state = 19
+    case state_house = 20
+    case state_senate = 21
+    case township = 22
+    case utility = 23
+    case village = 24
+    case vote_center = 25
+    case ward = 26
+    case water = 27
+    case other = 28
 }

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Services/EGDataService.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Services/EGDataService.swift
@@ -8,20 +8,52 @@
 
 import Foundation
 
-class EGDataService {
+class EGDataService: HttpDataService {
     static let shared = EGDataService()
 
     // Dictionary for keeping track of cast ballots in memory (demo purposes only)
     var votes = [String: Bool]() // Key: contestId; Value: True (if cast), False (if spoiled)
 
-    private init() { }
+    // Local cache of manifest
+    private var manifest: ElectionDescription?
     
-    func getElectionManifest() -> ElectionDescription? {
-        let json = """
-    {"ballot_styles": [{"geopolitical_unit_ids": ["hamilton-county"], "object_id": "congress-district-7-hamilton-county"}], "candidates": [{"ballot_name": {"text": [{"language": "en", "value": "Joseph Barchi"}]}, "object_id": "barchi"}, {"ballot_name": {"text": [{"language": "en", "value": "Adam Cramer"}]}, "object_id": "cramer"}, {"ballot_name": {"text": [{"language": "en", "value": "Daniel Court"}]}, "object_id": "court"}, {"ballot_name": {"text": [{"language": "en", "value": "Alvin Boone"}]}, "object_id": "boone"}, {"ballot_name": {"text": [{"language": "en", "value": "Ashley Hildebrand-McDougall"}]}, "object_id": "hildebrand"}, {"ballot_name": {"text": [{"language": "en", "value": "Martin Patterson"}]}, "object_id": "patterson"}, {"ballot_name": {"text": [{"language": "en", "value": "Charlene Franz"}]}, "object_id": "franz"}, {"ballot_name": {"text": [{"language": "en", "value": "Gerald Harris"}]}, "object_id": "harris"}, {"ballot_name": {"text": [{"language": "en", "value": "Linda Bargmann"}]}, "object_id": "bargmann"}, {"ballot_name": {"text": [{"language": "en", "value": "Barbara Abcock"}]}, "object_id": "abcock"}], "contests": [{"@type": "CandidateContest", "ballot_selections": [{"candidate_id": "barchi", "object_id": "barchi-selection", "sequence_order": 0}, {"candidate_id": "cramer", "object_id": "cramer-selection", "sequence_order": 1}, {"candidate_id": "court", "object_id": "court-selection", "sequence_order": 2}, {"candidate_id": "boone", "object_id": "boone-selection", "sequence_order": 3}, {"candidate_id": "hildebrand", "object_id": "hildebrand-selection", "sequence_order": 4}, {"candidate_id": "patterson", "object_id": "patterson-selection", "sequence_order": 5}, {"candidate_id": "franz", "object_id": "franz-selection", "sequence_order": 6}, {"candidate_id": "harris", "object_id": "harris-selection", "sequence_order": 7}, {"candidate_id": "bargmann", "object_id": "bargmann-selection", "sequence_order": 8}, {"candidate_id": "abcock", "object_id": "abcock-selection", "sequence_order": 9}], "ballot_subtitle": {"text": [{"language": "en", "value": "Vote for one"}, {"language": "es", "value": "Votar por uno"}]}, "ballot_title": {"text": [{"language": "en", "value": "Hamilton County School Board"}, {"language": "es", "value": "Junta Escolar del Condado de Hamilton"}]}, "electoral_district_id": "hamilton-county", "name": "Hamilton County School Board", "number_elected": 1, "object_id": "school-board-contest", "sequence_order": 0, "vote_variation": "one_of_m", "votes_allowed": 1}], "election_scope_id": "hamilton-county-general-election", "end_date": "2020-03-01T20:00:00-05:00", "geopolitical_units": [{"contact_information": {"address_line": ["1234 Samuel Adams Way", "Hamilton, Ozark 99999"], "email": [{"annotation": "inquiries", "value": "inquiries@hamiltoncounty.gov"}], "name": "Hamilton County Clerk", "phone": [{"annotation": "domestic", "value": "123-456-7890"}]}, "name": "Hamilton County", "object_id": "hamilton-county", "type": "county"}], "name": {"text": [{"language": "en", "value": "Hamiltion County General Election"}, {"language": "es", "value": "Elección general del condado de Hamilton"}]}, "parties": [], "start_date": "2020-03-01T08:00:00-05:00", "type": "general"}
-    """
+    private override init() { }
+    
+    func downloadElectionManifest(loadSampleElectionOnFailure: Bool = false, completion: @escaping (ElectionDescription?) -> Void) {
+        sendRequest(url: "\(Constants.BaseApiUrl)/election/description") { (result: APIResult<ElectionDescription>?, error) in
+            guard
+                error == nil,
+                let manifest = result?.data
+            else {
+                
+                if loadSampleElectionOnFailure {
+                    let manifest = self.getSampleElectionManifest()
+                    completion(manifest)
+                } else {
+                    completion(nil)
+                }
+
+                return
+            }
+
+            // Cache the manifest
+            self.manifest = manifest
             
-        return JsonHelper.fromJson(json.data(using: .utf8)!)
+            completion(manifest)
+        }
+    }
+    
+    func getSampleElectionManifest() -> ElectionDescription? {
+        let json = """
+    {"ballot_styles": [{"geopolitical_unit_ids": ["hamilton-county"], "object_id": "congress-district-7-hamilton-county"}], "candidates": [{"ballot_name": {"text": [{"language": "en", "value": "Joseph Barchi"}]}, "object_id": "barchi"}, {"ballot_name": {"text": [{"language": "en", "value": "Adam Cramer"}]}, "object_id": "cramer"}, {"ballot_name": {"text": [{"language": "en", "value": "Daniel Court"}]}, "object_id": "court"}, {"ballot_name": {"text": [{"language": "en", "value": "Alvin Boone"}]}, "object_id": "boone"}, {"ballot_name": {"text": [{"language": "en", "value": "Ashley Hildebrand-McDougall"}]}, "object_id": "hildebrand"}, {"ballot_name": {"text": [{"language": "en", "value": "Martin Patterson"}]}, "object_id": "patterson"}, {"ballot_name": {"text": [{"language": "en", "value": "Charlene Franz"}]}, "object_id": "franz"}, {"ballot_name": {"text": [{"language": "en", "value": "Gerald Harris"}]}, "object_id": "harris"}, {"ballot_name": {"text": [{"language": "en", "value": "Linda Bargmann"}]}, "object_id": "bargmann"}, {"ballot_name": {"text": [{"language": "en", "value": "Barbara Abcock"}]}, "object_id": "abcock"}], "contests": [{"@type": "CandidateContest", "ballot_selections": [{"candidate_id": "barchi", "object_id": "barchi-selection", "sequence_order": 0}, {"candidate_id": "cramer", "object_id": "cramer-selection", "sequence_order": 1}, {"candidate_id": "court", "object_id": "court-selection", "sequence_order": 2}, {"candidate_id": "boone", "object_id": "boone-selection", "sequence_order": 3}, {"candidate_id": "hildebrand", "object_id": "hildebrand-selection", "sequence_order": 4}, {"candidate_id": "patterson", "object_id": "patterson-selection", "sequence_order": 5}, {"candidate_id": "franz", "object_id": "franz-selection", "sequence_order": 6}, {"candidate_id": "harris", "object_id": "harris-selection", "sequence_order": 7}, {"candidate_id": "bargmann", "object_id": "bargmann-selection", "sequence_order": 8}, {"candidate_id": "abcock", "object_id": "abcock-selection", "sequence_order": 9}], "ballot_subtitle": {"text": [{"language": "en", "value": "Vote for one"}, {"language": "es", "value": "Votar por uno"}]}, "ballot_title": {"text": [{"language": "en", "value": "Hamilton County School Board"}, {"language": "es", "value": "Junta Escolar del Condado de Hamilton"}]}, "electoral_district_id": "hamilton-county", "name": "Hamilton County School Board", "number_elected": 1, "object_id": "school-board-contest", "sequence_order": 0, "vote_variation": 1, "votes_allowed": 1}], "election_scope_id": "hamilton-county-general-election", "end_date": "2020-03-01T20:00:00-05:00", "geopolitical_units": [{"contact_information": {"address_line": ["1234 Samuel Adams Way", "Hamilton, Ozark 99999"], "email": [{"annotation": "inquiries", "value": "inquiries@hamiltoncounty.gov"}], "name": "Hamilton County Clerk", "phone": [{"annotation": "domestic", "value": "123-456-7890"}]}, "name": "Hamilton County", "object_id": "hamilton-county", "type": 9}], "name": {"text": [{"language": "en", "value": "Hamiltion County General Election"}, {"language": "es", "value": "Elección general del condado de Hamilton"}]}, "parties": [], "start_date": "2020-03-01T08:00:00-05:00", "type": 1}
+    """
+        
+        let manifest: ElectionDescription? = JsonHelper.fromJson(json.data(using: .utf8)!)
+        
+        // Cache the manifest
+        self.manifest = manifest
+        
+        return manifest
     }
     
     func getElectionContext() -> CiphertextElectionContext? {
@@ -32,9 +64,12 @@ class EGDataService {
         return JsonHelper.fromJson(json.data(using: .utf8)!)
     }
     
-    func getCandidateName(forId id: String) -> InternationalizedText? {
-        let manifest = getElectionManifest()
-        let candidate = manifest?.candidates?.first(where: { $0.objectId == id })
+    func getContests() -> [ContestDescription]? {
+        return manifest?.contests
+    }
+    
+    func getCandidateName(objectId: String) -> InternationalizedText? {
+        let candidate = manifest?.candidates?.first(where: { $0.objectId == objectId })
         
         return candidate?.ballotName
     }

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Services/HttpDataService.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Services/HttpDataService.swift
@@ -1,0 +1,59 @@
+//
+//  HttpDataService.swift
+//  ElectionGuardDemo
+//
+//  Created by Ed Snider on 9/4/20.
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+import Foundation
+
+struct APIResult<T> {
+    var data: T?
+}
+
+struct APIResultError: Error {
+    let message: String?
+}
+
+class HttpDataService {
+    func sendRequest<T: Decodable>(url: String, httpMethod: String? = "GET", completion: @escaping ((APIResult<T>?, APIResultError?) -> Void)) {
+        guard let url = URL(string: url) else {
+            print("Error constructing URL request for endpoint")
+            return
+        }
+        
+        let request = URLRequest(url: url)
+        let session = URLSession.shared
+        let task = session.dataTask(with: request) { data, response, error in
+            guard error == nil else {
+                completion(nil, error as? APIResultError)
+                return
+            }
+            
+            guard let response = response as? HTTPURLResponse else {
+                completion(nil, APIResultError(message: "Response is NULL"))
+                return
+            }
+            
+            if response.statusCode >= 400 {
+                completion(nil, APIResultError(message: "Response returned unsuccessful status code: \(response.statusCode)"))
+                return
+            }
+            
+            guard let data = data else {
+                completion(nil, APIResultError(message: "Response data is NULL"))
+                return
+            }
+            
+            guard let result: T? = JsonHelper.fromJson(data) else {
+                completion(nil, APIResultError(message: "Response decoding failed"))
+                return
+            }
+            
+            completion(APIResult(data: result), nil)
+        }
+        
+        task.resume()
+    }
+}

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/ViewControllers/ContestViewController.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/ViewControllers/ContestViewController.swift
@@ -119,10 +119,10 @@ class ContestViewController: UIViewController {
     }
     
     private func loadSelections() {
-        let election = EGDataService.shared.getElectionManifest()
+        let contests = EGDataService.shared.getContests()
         let language = "en"
         
-        guard let contest = election?.contests?.first(where: { $0.objectId == contestId }) else {
+        guard let contest = contests?.first(where: { $0.objectId == contestId }) else {
             showDialog(title: "Contest Not Found", body: "The contest could not be found. Please go back and try again.", okText: "OK")
             return
         }

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/ViewControllers/MainViewController.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/ViewControllers/MainViewController.swift
@@ -131,11 +131,18 @@ class MainViewController: UIViewController {
     }
     
     private func loadData() {
-        let election = EGDataService.shared.getElectionManifest()
-        
-        electionNameLabel.text = election?.name?.text?.first?.value
-        activeContest = election?.contests?.first
-
+        ProgressHUD.show("Downloading Election Manifest...", interaction: false)
+        EGDataService.shared.downloadElectionManifest(loadSampleElectionOnFailure: true) { election in
+            ProgressHUD.dismiss()
+            DispatchQueue.main.async {
+                self.electionNameLabel.text = election?.name?.text?.first?.value
+                self.activeContest = election?.contests?.first
+                self.setupForActiveContest()
+            }
+        }
+    }
+    
+    func setupForActiveContest() {
         guard activeContest != nil else {
             contestNameLabel.text = "There is currently not an active contest available"
             beginButton.isHidden = true

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/ViewControllers/ReviewViewController.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/ViewControllers/ReviewViewController.swift
@@ -87,7 +87,7 @@ class ReviewViewController: UIViewController {
     private func loadCandidate() {
         guard
             let candidateId = selection?.candidateId,
-            let candidateName = EGDataService.shared.getCandidateName(forId: candidateId)?.text?.first(where: { $0.language == "en" })?.value
+            let candidateName = EGDataService.shared.getCandidateName(objectId: candidateId)?.text?.first(where: { $0.language == "en" })?.value
         else {
             showDialog(title: "Selection Not Found", body: "There was a problem with your selection. Please go back and try again.", okText: "OK")
             return

--- a/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Views/SelectionCollectionViewCell.swift
+++ b/apps/demo_in_swift/ElectionGuardDemo/ElectionGuardDemo/Views/SelectionCollectionViewCell.swift
@@ -53,7 +53,7 @@ class SelectionCollectionViewCell: UICollectionViewCell {
             return
         }
         
-        let candidateName = EGDataService.shared.getCandidateName(forId: candidateId)?
+        let candidateName = EGDataService.shared.getCandidateName(objectId: candidateId)?
                                 .text?.first(where: { $0.language == "en" })?.value
         
         nameLabel.text = candidateName ?? ""


### PR DESCRIPTION
### Description
- Updated demo iOS app to download election manifest from API. If API is not available it will load the hardcoded sample manifest.
  - Once the manifest has been downloaded the `EGDataService` keeps it in memory so the app is able to lookup contests and candidates later.
- Updated enums to `Int` to match the incoming data from the API. 

### Testing
- Run the python API locally - see web-api [README](https://github.com/microsoft/electionguard-web-api/tree/python-api) setup instructions
- Run in simulator or on a physical device. See README instructions for how to pull in the electionguard-core binary dependency.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💔Thank you!