### PR TITLE
Fix Build warning C4068 for MSVC

### DIFF
--- a/src/electionguard/utils.hpp
+++ b/src/electionguard/utils.hpp
@@ -38,10 +38,16 @@ namespace electionguard
     {
         auto now = system_clock::now();
         auto ticks = now.time_since_epoch();
+
+#if defined(__GNUC__)        
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif // __GNUC__
         return ticks.count() * system_clock::period::num / system_clock::period::den;
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif // __GNUC__
+
     }
 
     /// <Summary>


### PR DESCRIPTION
Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>

[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #216

### Description

- GCC pragma is not a valid pragma in MSVC, thus produces warning C4068:
unknown pragma 'GCC'.
- The workaround is to encapsulate the GCC pragma in if GNUC defined
block.

### Testing
*Describe the best way to test or validate your PR.*
- Please approve for the first run and it will validate itself 😄 

