### PR TITLE
fix crash on overvote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ cmake/CPM.cmake
 
 cmake/ios.toolchain.cmake
 
+data/0.95.0/
+
 ### Xcode and Swift ###
 
 # Created by https://www.toptal.com/developers/gitignore/api/swift,xcode
@@ -145,3 +147,5 @@ appsettings.json
 cmake/CPM_0.31.0.cmake
 
 bindings/netframework/ElectionGuard.NetFramework/packages/
+
+sample-data.zip

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ cmake/CPM_0.31.0.cmake
 bindings/netframework/ElectionGuard.NetFramework/packages/
 
 sample-data.zip
+
+sample-data-container.zip

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,6 +93,10 @@
         "unordered_set": "cpp",
         "hash_map": "cpp",
         "ranges": "cpp",
-        "stop_token": "cpp"
+        "stop_token": "cpp",
+        "ballot.h": "c",
+        "election.h": "c",
+        "manifest.h": "c",
+        "__bits": "cpp"
     },
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ option(CAN_USE_VECTOR_INTRINSICS "Use vector intrinsics for math functions if av
 option(USE_32BIT_MATH            "Use the 32 bit optimized math impl"                        OFF)
 option(USE_TEST_PRIMES           "Use the smaller test primes (do not use in prod)"          OFF)
 option(OPTION_ENABLE_TESTS       "Enable support for testing private headers"                OFF)
+option(TEST_SPEC_VERSION         "Use this spec version for tests"                           "0.95.0")
+option(TEST_USE_SAMPLE           "the sample to use, full, hamilton-general, minimal, small" "hamilton-general")
 option(CODE_COVERAGE             "Use code coverage"                                         OFF)
 option(OPTION_GENERATE_DOCS      "Generate documentation"                                    OFF)
 option(USE_DYNAMIC_ANALYSIS      "Enable Dynamic tools"                                      OFF)

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ ifeq ($(OPERATING_SYSTEM),Windows)
 	choco install wget
 endif
 	wget -O cmake/CPM.cmake https://github.com/TheLartians/CPM.cmake/releases/latest/download/CPM.cmake
+	# TODO: add wget -0 sample-data.zip ...
+	unzip sample-data.zip
+
 
 build:
 	@echo 🧱 BUILD $(TARGET)
@@ -301,6 +304,7 @@ else
 	dotnet ./bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Bench/bin/x64/$(TARGET)/net5.0/ElectionGuard.Encryption.Bench.dll
 endif
 
+# Test
 test:
 	@echo 🧪 TEST
 ifeq ($(OPERATING_SYSTEM),Windows)
@@ -376,3 +380,8 @@ endif
 	cmake --build $(ELECTIONGUARD_BUILD_LIBS_DIR)/x86_64/$(TARGET)
 	$(ELECTIONGUARD_BUILD_LIBS_DIR)/x86_64/$(TARGET)/test/ElectionGuardTests
 	$(ELECTIONGUARD_BUILD_LIBS_DIR)/x86_64/$(TARGET)/test/ElectionGuardCTests
+
+# Sample Data
+
+generate-sample-data:
+	@echo Generate Sample Data

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,11 @@ endif
 ifeq ($(OPERATING_SYSTEM),Windows)
 	@echo 🏁 WINDOWS INSTALL
 	choco install wget
+	choco install unzip
 endif
 	wget -O cmake/CPM.cmake https://github.com/TheLartians/CPM.cmake/releases/latest/download/CPM.cmake
 	wget -O sample-data.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
+	unzip -o sample-data.zip
 	unzip sample-data.zip
 
 

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ ifeq ($(OPERATING_SYSTEM),Windows)
 	choco install unzip
 endif
 	wget -O cmake/CPM.cmake https://github.com/TheLartians/CPM.cmake/releases/latest/download/CPM.cmake
-	wget -O sample-data.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
-	unzip -o sample-data.zip
+	wget -O sample-data-container.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
+	unzip -o sample-data-container.zip
 	unzip sample-data.zip
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ifeq ($(OPERATING_SYSTEM),Windows)
 	choco install wget
 endif
 	wget -O cmake/CPM.cmake https://github.com/TheLartians/CPM.cmake/releases/latest/download/CPM.cmake
-	# TODO: add wget -0 sample-data.zip ...
+	wget -O sample-data.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
 	unzip sample-data.zip
 
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 	wget -O cmake/CPM.cmake https://github.com/TheLartians/CPM.cmake/releases/latest/download/CPM.cmake
 	wget -O sample-data-container.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
 	unzip -o sample-data-container.zip
-	unzip sample-data.zip
+	unzip -o sample-data.zip
 
 
 build:

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/ElectionGuard.Encryption.Tests.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/ElectionGuard.Encryption.Tests.csproj
@@ -31,8 +31,6 @@
   </ItemGroup>
 
   <ItemGroup Label="Json Test Data">
-    <Content Include="..\..\..\..\data\ballot_in_simple.json" Link="Data\ballot_in_simple.json" CopyToOutputDirectory="Always" />
-    <Content Include="..\..\..\..\data\election_manifest_jefferson_county.json" Link="Data\election_manifest_jefferson_county.json" CopyToOutputDirectory="Always" />
-    <Folder Include="Data\" />
+    <Content Include="..\..\..\..\data\**" LinkBase="data\" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestEncrypt.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestEncrypt.cs
@@ -32,6 +32,8 @@ namespace ElectionGuard.Encrypt.Tests
             // a property
             Assert.That(ciphertext.ObjectId == ballot.ObjectId);
 
+            Assert.That(ciphertext.BallotCode.ToHex() != null);
+
             // json serialization
             var json = ciphertext.ToJson();
             var fromJson = new CiphertextBallot(json);
@@ -49,6 +51,50 @@ namespace ElectionGuard.Encrypt.Tests
             // submitted ballot
             var submitted = new SubmittedBallot(ciphertext, BallotBoxState.Cast);
             Assert.That(ciphertext.ObjectId == submitted.ObjectId);
+        }
+
+        [Test]
+        public void Test_Encrypt_Ballot_Undervote_Succeeds()
+        {
+            // Configure the election context
+            var keypair = ElGamalKeyPair.FromSecret(Constants.TWO_MOD_Q);
+            var manifest = ManifestGenerator.GetJeffersonCountyManifest_Minimal();
+            var internalManifest = new InternalManifest(manifest);
+            var context = new CiphertextElectionContext(
+                1UL, 1UL, keypair.PublicKey, Constants.TWO_MOD_Q, internalManifest.ManifestHash);
+            var device = new EncryptionDevice(12345UL, 23456UL, 34567UL, "Location");
+            var mediator = new EncryptionMediator(internalManifest, context, device);
+
+            // Act
+            var ballot = BallotGenerator.GetFakeBallot(internalManifest, 1);
+            var ciphertext = mediator.Encrypt(ballot);
+
+            // Assert
+
+            // a property
+            Assert.That(ciphertext.IsValidEncryption(context.ManifestHash, keypair.PublicKey, context.CryptoExtendedBaseHash));
+        }
+
+        [Test]
+        public void Test_Encrypt_Ballot_Overvote_Fails()
+        {
+            // Configure the election context
+            var keypair = ElGamalKeyPair.FromSecret(Constants.TWO_MOD_Q);
+            var manifest = ManifestGenerator.GetJeffersonCountyManifest_Minimal();
+            var internalManifest = new InternalManifest(manifest);
+            var context = new CiphertextElectionContext(
+                1UL, 1UL, keypair.PublicKey, Constants.TWO_MOD_Q, internalManifest.ManifestHash);
+            var device = new EncryptionDevice(12345UL, 23456UL, 34567UL, "Location");
+            var mediator = new EncryptionMediator(internalManifest, context, device);
+
+            // Act
+            var ballot = BallotGenerator.GetFakeBallot(internalManifest, 2);
+            var ciphertext = mediator.Encrypt(ballot);
+
+            // Assert
+
+            // a property
+            Assert.That(ciphertext.IsValidEncryption(context.ManifestHash, keypair.PublicKey, context.CryptoExtendedBaseHash));
         }
 
         [Test]

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestEncrypt.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestEncrypt.cs
@@ -89,12 +89,8 @@ namespace ElectionGuard.Encrypt.Tests
 
             // Act
             var ballot = BallotGenerator.GetFakeBallot(internalManifest, 2);
-            var ciphertext = mediator.Encrypt(ballot);
+            Assert.Throws<ArgumentException>(() => mediator.Encrypt(ballot));
 
-            // Assert
-
-            // a property
-            Assert.That(ciphertext.IsValidEncryption(context.ManifestHash, keypair.PublicKey, context.CryptoExtendedBaseHash));
         }
 
         [Test]

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -9,6 +9,15 @@ namespace ElectionGuard.Encrypt.Tests
     [TestFixture]
     public class TestManifest
     {
+        string TEST_SPEC_VERSION = "0.95.0";
+        string TEST_USE_SAMPLE = "hamilton-general";
+        [Test]
+        public void Test_Can_Serialize_Sample_manifest()
+        {
+            var subject = ManifestGenerator.GetManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
+            Assert.That(subject.IsValid);
+        }
+
         [Test]
         public void Test_Can_Construct_Internationalized_Text()
         {
@@ -37,10 +46,10 @@ namespace ElectionGuard.Encrypt.Tests
         }
 
         [Test]
-        public void Test_Can_Construct_InternalManifest_From_Manifest_Minimal()
+        public void Test_Can_Construct_InternalManifest_From_Sample_Manifest()
         {
             // Get a simple manifest that shows the bare minimum data required
-            var manifest = ManifestGenerator.GetJeffersonCountyManifest_Minimal();
+            var manifest = ManifestGenerator.GetManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
             var internalManifest = new InternalManifest(manifest);
 
             Assert.That(manifest.CryptoHash().ToHex() == internalManifest.ManifestHash.ToHex());

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/Utils/Ballot.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/Utils/Ballot.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ElectionGuard.Encryption;
+
+namespace ElectionGuard.Encryption.Tests.Utils
+{
+    public class BallotGenerator
+    {
+        public static PlaintextBallotSelection SelectionFrom(SelectionDescription description, bool isAffirmative = false, bool isPlaceholder = false)
+        {
+            return new PlaintextBallotSelection(description.ObjectId, isAffirmative ? 1UL : 0UL, isPlaceholder);
+        }
+
+        public static PlaintextBallotContest ContestFrom(ContestDescription contest, uint maxChoices)
+        {
+            uint choices = 0;
+            List<PlaintextBallotSelection> selections = new List<PlaintextBallotSelection>();
+
+            for (ulong i = 0; i < contest.SelectionsSize; i++)
+            {
+                if (choices < maxChoices)
+                {
+                    ++choices;
+                    selections.Add(SelectionFrom(contest.GetSelectionAtIndex(i), true));
+                }
+                else
+                {
+                    selections.Add(SelectionFrom(contest.GetSelectionAtIndex(i), false));
+                }
+            }
+
+            return new PlaintextBallotContest(contest.ObjectId, selections.ToArray());
+        }
+
+        public static PlaintextBallot GetFakeBallot(InternalManifest manifest, uint maxChoices = 1)
+        {
+            string ballotId = "ballot-id-123";
+
+            List<PlaintextBallotContest> contests = new List<PlaintextBallotContest>();
+            for (ulong i = 0; i < manifest.ContestsSize; i++)
+            {
+                contests.Add(ContestFrom(manifest.GetContestAtIndex(i), maxChoices));
+            }
+
+            return new PlaintextBallot(ballotId, manifest.GetBallotStyleAtIndex(0).ObjectId, contests.ToArray());
+        }
+    }
+}

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/Utils/Manifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/Utils/Manifest.cs
@@ -14,7 +14,20 @@ namespace ElectionGuard.Encryption.Tests.Utils
         /// </summary>
         public static Manifest GetJeffersonCountyManifest_FromFile()
         {
-            var path = Path.Combine(AppContext.BaseDirectory, "Data", "election_manifest_jefferson_county.json");
+            var path = Path.Combine(AppContext.BaseDirectory, "data", "election_manifest_jefferson_county.json");
+            var text = File.ReadAllText(path);
+            return new Manifest(text);
+        }
+
+        public static Manifest GetManifestFromFile(string version, string sample)
+        {
+            var path = Path.Combine(version, "sample", sample, "manifest.json");
+            return GetManifestFromFile(path);
+        }
+
+        public static Manifest GetManifestFromFile(string filepath)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "data", filepath);
             var text = File.ReadAllText(path);
             return new Manifest(text);
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Encrypt.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Encrypt.cs
@@ -31,10 +31,7 @@ namespace ElectionGuard
         {
             var status = NativeInterface.EncryptionDevice.New(
                 deviceUuid, sessionUuid, launchCode, location, out Handle);
-            if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-            {
-                Console.WriteLine($"EncryptionDevice New Error Status: {status}");
-            }
+            status.ThrowIfError();
         }
 
         protected override unsafe void DisposeUnmanaged()
@@ -83,20 +80,14 @@ namespace ElectionGuard
             {
                 var status = NativeInterface.EncryptionMediator.EncryptAndVerify(
                 Handle, plaintext.Handle, out NativeCiphertextBallot ciphertext);
-                if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-                {
-                    Console.WriteLine($"Encrypt Error Status: {status}");
-                }
+                status.ThrowIfError();
                 return new CiphertextBallot(ciphertext);
             }
             else
             {
                 var status = NativeInterface.EncryptionMediator.Encrypt(
                 Handle, plaintext.Handle, out NativeCiphertextBallot ciphertext);
-                if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-                {
-                    Console.WriteLine($"Encrypt Error Status: {status}");
-                }
+                status.ThrowIfError();
                 return new CiphertextBallot(ciphertext);
             }
 
@@ -112,20 +103,14 @@ namespace ElectionGuard
             {
                 var status = NativeInterface.EncryptionMediator.CompactEncryptAndVerify(
                 Handle, plaintext.Handle, out NativeCompactCiphertextBallot ciphertext);
-                if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-                {
-                    Console.WriteLine($"InternalManifest Error Status: {status}");
-                }
+                status.ThrowIfError();
                 return new CompactCiphertextBallot(ciphertext);
             }
             else
             {
                 var status = NativeInterface.EncryptionMediator.CompactEncrypt(
                 Handle, plaintext.Handle, out NativeCompactCiphertextBallot ciphertext);
-                if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-                {
-                    Console.WriteLine($"InternalManifest Error Status: {status}");
-                }
+                status.ThrowIfError();
                 return new CompactCiphertextBallot(ciphertext);
             }
 
@@ -177,10 +162,7 @@ namespace ElectionGuard
                     ballot.Handle, internalManifest.Handle, context.Handle,
                     ballotCodeSeed.Handle, shouldVerifyProofs,
                     out NativeCiphertextBallot ciphertext);
-                if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-                {
-                    Console.WriteLine($"Encrypt Ballot Error Status: {status}");
-                }
+                status.ThrowIfError();
                 return new CiphertextBallot(ciphertext);
             }
             else
@@ -189,10 +171,7 @@ namespace ElectionGuard
                     ballot.Handle, internalManifest.Handle, context.Handle,
                     ballotCodeSeed.Handle, nonce.Handle, shouldVerifyProofs,
                     out NativeCiphertextBallot ciphertext);
-                if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-                {
-                    Console.WriteLine($"EncryptWithNonce Ballot Error Status: {status}");
-                }
+                status.ThrowIfError();
                 return new CiphertextBallot(ciphertext);
             }
         }
@@ -232,10 +211,7 @@ namespace ElectionGuard
                 ballot.Handle, internalManifest.Handle, context.Handle,
                 ballotCodeSeed.Handle, verifyProofs,
                 out NativeCompactCiphertextBallot ciphertext);
-            if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
-            {
-                Console.WriteLine($"Encrypt CompactBallot Error Status: {status}");
-            }
+            status.ThrowIfError();
             return new CompactCiphertextBallot(ciphertext);
         }
     }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/NativeInterface.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/NativeInterface.cs
@@ -18,6 +18,37 @@ namespace ElectionGuard
         /// This code should always be the last code in the collection
         // so that the status codes string can be correctly derived
         ELECTIONGUARD_STATUS_UNKNOWN
+
+
+    }
+
+    static internal class StatusExtensions
+    {
+        public static void ThrowIfError(this Status status)
+        {
+            switch (status)
+            {
+                case Status.ELECTIONGUARD_STATUS_SUCCESS:
+                    return;
+                case Status.ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT:
+                    throw new ArgumentException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_ERROR_OUT_OF_RANGE:
+                    throw new ArgumentOutOfRangeException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_ERROR_IO_ERROR:
+                    throw new SystemException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_ERROR_BAD_ACCESS:
+                    throw new AccessViolationException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC:
+                    throw new OutOfMemoryException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_ERROR_ALREADY_EXISTS:
+                    throw new TypeLoadException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR:
+                    throw new AggregateException($"{status}");
+                case Status.ELECTIONGUARD_STATUS_UNKNOWN:
+                default:
+                    throw new Exception($"{status}");
+            }
+        }
     }
 
     /// <Summary>
@@ -677,7 +708,7 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_internationalized_text_new", 
+            [DllImport(DllName, EntryPoint = "eg_internationalized_text_new",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
                 // TODO: type safety
@@ -1298,13 +1329,13 @@ namespace ElectionGuard
             [DllImport(DllName, EntryPoint = "eg_contest_description_get_ballot_title",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotTitle(
-                ContestDescriptionHandle handle, 
+                ContestDescriptionHandle handle,
                 out InternationalizedText.InternationalizedTextHandle name);
 
             [DllImport(DllName, EntryPoint = "eg_contest_description_get_ballot_subtitle",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotSubTitle(
-                ContestDescriptionHandle handle, 
+                ContestDescriptionHandle handle,
                 out InternationalizedText.InternationalizedTextHandle name);
 
             [DllImport(DllName, EntryPoint = "eg_contest_description_get_selections_size",
@@ -1388,7 +1419,7 @@ namespace ElectionGuard
                 ulong placeholdersSize,
                 out ContestDescriptionWithPlaceholdersHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_contest_description_with_placeholders_new_with_parties",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
@@ -1409,7 +1440,7 @@ namespace ElectionGuard
                 ulong placeholdersSize,
                 out ContestDescriptionWithPlaceholdersHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_contest_description_with_placeholders_new_with_title_and_parties",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
@@ -1481,13 +1512,13 @@ namespace ElectionGuard
             [DllImport(DllName, EntryPoint = "eg_contest_description_get_ballot_title",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotTitle(
-                ContestDescriptionWithPlaceholdersHandle handle, 
+                ContestDescriptionWithPlaceholdersHandle handle,
                 out InternationalizedText.InternationalizedTextHandle name);
 
             [DllImport(DllName, EntryPoint = "eg_contest_description_get_ballot_subtitle",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotSubTitle(
-                ContestDescriptionWithPlaceholdersHandle handle, 
+                ContestDescriptionWithPlaceholdersHandle handle,
                 out InternationalizedText.InternationalizedTextHandle name);
 
             [DllImport(DllName, EntryPoint = "eg_contest_description_get_selections_size",
@@ -1510,13 +1541,13 @@ namespace ElectionGuard
 
             #endregion
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_contest_description_with_placeholders_get_placeholders_size",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetPlaceholdersSize(
                 ContestDescriptionWithPlaceholdersHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_contest_description_with_placeholders_get_placeholder_at_index",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetPlaceholderAtIndex(
@@ -1524,14 +1555,14 @@ namespace ElectionGuard
                 ulong index,
                 out SelectionDescription.SelectionDescriptionHandle partyId);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_contest_description_with_placeholders_is_placeholder",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool IsPlaceholder(
-                ContestDescriptionWithPlaceholdersHandle handle, 
+                ContestDescriptionWithPlaceholdersHandle handle,
                 SelectionDescription.SelectionDescriptionHandle selection);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_contest_description_with_placeholders_selection_for_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status SelectionForId(
@@ -1771,13 +1802,13 @@ namespace ElectionGuard
                 InternalManifestHandle handle,
                 out ElementModQ.ElementModQHandle manifest_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_internal_manifest_get_geopolitical_units_size",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetGeopoliticalUnitsSize(
                 InternalManifestHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_internal_manifest_get_geopolitical_unit_at_index",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetGeopoliticalUnitAtIndex(
@@ -1870,35 +1901,35 @@ namespace ElectionGuard
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(CiphertextElectionType* handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_election_context_get_elgamal_public_key",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetElGamalPublicKey(
                 CiphertextElectionContextHandle handle,
                 out ElementModP.ElementModPHandle elgamal_public_key);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_election_context_get_commitment_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCommitmentHash(
                 CiphertextElectionContextHandle handle,
                 out ElementModQ.ElementModQHandle commitment_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_election_context_get_manifest_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetManifestHash(
                 CiphertextElectionContextHandle handle,
                 out ElementModQ.ElementModQHandle manifest_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_election_context_get_crypto_base_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCryptoBaseHash(
                 CiphertextElectionContextHandle handle,
                 out ElementModQ.ElementModQHandle crypto_base_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_election_context_get_crypto_extended_base_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCryptoExtendedBaseHash(
@@ -2027,7 +2058,7 @@ namespace ElectionGuard
                 bool isPlaceholderSelection,
                 out PlaintextBallotSelectionHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_plaintext_ballot_selection_new_with_extended_data",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
@@ -2052,13 +2083,13 @@ namespace ElectionGuard
             internal static extern ulong GetVote(
                 PlaintextBallotSelectionHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_plaintext_ballot_selection_get_is_placeholder",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool GetIsPlaceholder(
                 PlaintextBallotSelectionHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_plaintext_ballot_selection_get_extended_data",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetExtendedData(
@@ -2101,54 +2132,54 @@ namespace ElectionGuard
             internal static extern Status GetObjectId(
                 CiphertextBallotSelectionHandle handle, out IntPtr object_id);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_sequence_order",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetSequenceOrder(
                 CiphertextBallotSelectionHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_description_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetDescriptionHash(
                 CiphertextBallotSelectionHandle handle,
                 out ElementModQ.ElementModQHandle description_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_is_placeholder",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool GetIsPlaceholder(
                 CiphertextBallotSelectionHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_ciphertext",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCiphertext(
                 CiphertextBallotSelectionHandle handle,
                 out ElGamalCiphertext.ElGamalCiphertextHandle ciphertext);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_crypto_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCryptoHash(
                 CiphertextBallotSelectionHandle handle,
                 out ElementModQ.ElementModQHandle cryptoHash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_nonce",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetNonce(
                 CiphertextBallotSelectionHandle handle,
                 out ElementModQ.ElementModQHandle nonce);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_get_proof",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetProof(
                 CiphertextBallotSelectionHandle handle,
                 out DisjunctiveChaumPedersenProof.DisjunctiveChaumPedersenProofHandle nonce);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_crypto_hash_with",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status CryptoHashWith(
@@ -2156,7 +2187,7 @@ namespace ElectionGuard
                 ElementModQ.ElementModQHandle encryption_seed,
                 out ElementModQ.ElementModQHandle crypto_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_selection_is_valid_encryption",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool IsValidEncryption(
@@ -2260,25 +2291,25 @@ namespace ElectionGuard
             internal static extern Status GetObjectId(
                 CiphertextBallotContestHandle handle, out IntPtr object_id);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_contest_get_sequence_order",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetSequenceOrder(CiphertextBallotContestHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_contest_get_description_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetDescriptionHash(
                 CiphertextBallotContestHandle handle,
                 out ElementModQ.ElementModQHandle description_hash);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_contest_get_selections_size",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetSelectionsSize(
                 CiphertextBallotContestHandle handle);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_contest_get_selection_at_index",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetSelectionAtIndex(
@@ -2292,51 +2323,51 @@ namespace ElectionGuard
                 CiphertextBallotContestHandle handle,
                 out ElementModQ.ElementModQHandle nonce);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_ciphertext_ballot_contest_get_ciphertext_accumulation",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCiphertextAccumulation(
                 CiphertextBallotContestHandle handle,
                 out ElGamalCiphertext.ElGamalCiphertextHandle nonce);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_ciphertext_ballot_contest_get_crypto_hash", 
+            [DllImport(DllName,
+                EntryPoint = "eg_ciphertext_ballot_contest_get_crypto_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCryptoHash(
                 CiphertextBallotContestHandle handle,
                 out ElementModQ.ElementModQHandle cryptoHash);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_ciphertext_ballot_contest_get_proof", 
+            [DllImport(DllName,
+                EntryPoint = "eg_ciphertext_ballot_contest_get_proof",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetProof(
                 CiphertextBallotContestHandle handle,
                 out ConstantChaumPedersenProof.ConstantChaumPedersenProofHandle nonce);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_ciphertext_ballot_contest_crypto_hash_with", 
+            [DllImport(DllName,
+                EntryPoint = "eg_ciphertext_ballot_contest_crypto_hash_with",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status CryptoHashWith(
                 CiphertextBallotContestHandle handle,
                 ElementModQ.ElementModQHandle encryption_seed,
                 out ElementModQ.ElementModQHandle crypto_hash);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_ciphertext_ballot_contest_aggregate_nonce", 
+            [DllImport(DllName,
+                EntryPoint = "eg_ciphertext_ballot_contest_aggregate_nonce",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status AggregateNonce(
                 CiphertextBallotContestHandle handle,
                 out ElementModQ.ElementModQHandle aggregate_nonce);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_ciphertext_ballot_contest_elgamal_accumulate", 
+            [DllImport(DllName,
+                EntryPoint = "eg_ciphertext_ballot_contest_elgamal_accumulate",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ElGamalAccumulate(
                 CiphertextBallotContestHandle handle,
                 out ElGamalCiphertext.ElGamalCiphertextHandle ciphertext_accumulation);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_ciphertext_ballot_selection_is_valid_encryption", 
+            [DllImport(DllName,
+                EntryPoint = "eg_ciphertext_ballot_selection_is_valid_encryption",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool IsValidEncryption(
                 CiphertextBallotContestHandle handle,
@@ -2367,8 +2398,8 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_plaintext_ballot_new", 
+            [DllImport(DllName,
+                EntryPoint = "eg_plaintext_ballot_new",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
                 [MarshalAs(UnmanagedType.LPStr)] string objectId,
@@ -2378,58 +2409,58 @@ namespace ElectionGuard
                 ulong contestsSize,
                 out PlaintextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_free", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(PlaintextBallotType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_object_id", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_object_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetObjectId(
                 PlaintextBallotHandle handle, out IntPtr object_id);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_style_id", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_style_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetStyleId(
                 PlaintextBallotHandle handle, out IntPtr style_id);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_contests_size", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_contests_size",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetContestsSize(PlaintextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_contest_at_index", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_get_contest_at_index",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetContestAtIndex(
                 PlaintextBallotHandle handle,
                 ulong index,
                 out PlaintextBallotContest.PlaintextBallotContestHandle contest);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_from_json", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_from_json",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromJson(
                 [MarshalAs(UnmanagedType.LPStr)] string data,
                 out PlaintextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_from_bson", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_from_bson",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromBson(
                 byte* data, ulong length, out PlaintextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_from_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_from_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromMsgPack(
                 byte* data, ulong length, out PlaintextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_to_json", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_to_json",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToJson(
                 PlaintextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_to_bson", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_to_bson",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToBson(
                 PlaintextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_to_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_plaintext_ballot_to_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToMsgPack(
                 PlaintextBallotHandle handle, out IntPtr data, out ulong size);
@@ -2459,21 +2490,21 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_free", 
+            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(CompactPlaintextBallotType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_from_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_from_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromMsgPack(
                 byte* data, ulong size, out CompactPlaintextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_to_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_to_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToMsgPack(
                 CompactPlaintextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_msgpack_free", 
+            [DllImport(DllName, EntryPoint = "eg_compact_plaintext_ballot_msgpack_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status MsgPackFree(IntPtr data);
         }
@@ -2500,75 +2531,75 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_free", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(CiphertextBallotType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_object_id", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_object_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetObjectId(
                 CiphertextBallotHandle handle, out IntPtr object_id);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_style_id", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_style_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetStyleId(
                 CiphertextBallotHandle handle, out IntPtr style_id);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_manifest_hash", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_manifest_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetManifestHash(
                 CiphertextBallotHandle handle,
                 out ElementModQ.ElementModQHandle manifest_hash_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code_seed", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code_seed",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotCodeSeed(
                 CiphertextBallotHandle handle,
                 out ElementModQ.ElementModQHandle ballot_code_seed_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contests_size", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contests_size",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetContestsSize(CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contest_at_index", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contest_at_index",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetContestAtIndex(
                 CiphertextBallotHandle handle,
                 ulong index,
                 out CiphertextBallotContest.CiphertextBallotContestHandle contest_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotCode(
                 CiphertextBallotHandle handle,
                 out ElementModQ.ElementModQHandle ballot_code_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_timestamp", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_timestamp",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetTimestamp(
                 CiphertextBallotHandle handle,
                 out ulong timestamp);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_nonce", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_nonce",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetNonce(
                 CiphertextBallotHandle handle,
                 out ElementModQ.ElementModQHandle nonce_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_crypto_hash", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_crypto_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCryptoHash(
                 CiphertextBallotHandle handle,
                 out ElementModQ.ElementModQHandle hash_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_crypto_hash_with", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_crypto_hash_with",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status CryptoHashWith(
                 CiphertextBallotHandle handle,
                 ElementModQ.ElementModQHandle manifest_hash,
                 out ElementModQ.ElementModQHandle crypto_hash);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_is_valid_encryption", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_is_valid_encryption",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool IsValidEncryption(
                 CiphertextBallotHandle handle,
@@ -2576,48 +2607,48 @@ namespace ElectionGuard
                 ElementModP.ElementModPHandle public_key,
                 ElementModQ.ElementModQHandle crypto_extended_base_hash);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_from_json", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_from_json",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromJson(
                 [MarshalAs(UnmanagedType.LPStr)] string data,
                 out CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_from_bson", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_from_bson",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromBson(
                 byte* data, ulong length, out CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_from_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_from_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromMsgPack(
                 byte* data, ulong length, out CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_json", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_json",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToJson(
                 CiphertextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_json_with_nonces", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_json_with_nonces",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToJsonWithNonces(
                 CiphertextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_bson", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_bson",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToBson(
                 CiphertextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_bson_with_nonces", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_bson_with_nonces",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToBsonWithNonces(
                 CiphertextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToMsgPack(
                 CiphertextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_msgpack_with_nonces", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_to_msgpack_with_nonces",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToMsgPackWithNonces(
                 CiphertextBallotHandle handle, out IntPtr data, out ulong size);
@@ -2645,26 +2676,26 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_free", 
+            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(CompactCiphertextBallotType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_get_object_id", 
+            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_get_object_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetObjectId(
                 CompactCiphertextBallotHandle handle, out IntPtr object_id);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_from_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_from_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromMsgPack(
                 byte* data, ulong size, out CompactCiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_to_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_to_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToMsgPack(
                 CompactCiphertextBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_msgpack_free", 
+            [DllImport(DllName, EntryPoint = "eg_compact_ciphertext_ballot_msgpack_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status MsgPackFree(IntPtr data);
 
@@ -2696,15 +2727,15 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_free", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(SubmittedBallotType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_get_state", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_get_state",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern BallotBoxState GetState(SubmittedBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status From(
                 CiphertextBallot.CiphertextBallotHandle ciphertext,
@@ -2716,46 +2747,46 @@ namespace ElectionGuard
             // Since the underlying c++ class inherits from CiphertextBallot
             // these functions call those methods subsituting the SubmittedBallot opaque pointer type
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_object_id", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_object_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetObjectId(
                 SubmittedBallotHandle handle, out IntPtr object_id);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_style_id", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_style_id",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetStyleId(
                SubmittedBallotHandle handle, out IntPtr style_id);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_manifest_hash", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_manifest_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetManifestHash(
                 SubmittedBallotHandle handle,
                 out ElementModQ.ElementModQHandle manifest_hash_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code_seed", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code_seed",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotCodeSeed(
                 SubmittedBallotHandle handle,
                 out ElementModQ.ElementModQHandle ballot_code_seed_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contests_size", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contests_size",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern ulong GetContestsSize(SubmittedBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contest_at_index", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_contest_at_index",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetContestAtIndex(
                 SubmittedBallotHandle handle,
                 ulong index,
                 out CiphertextBallotContest.CiphertextBallotContestHandle contest_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_ballot_code",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetBallotCode(
                 SubmittedBallotHandle handle,
                 out ElementModQ.ElementModQHandle ballot_code_ref);
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_timestamp", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_timestamp",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetTimestamp(
                 SubmittedBallotHandle handle,
@@ -2763,7 +2794,7 @@ namespace ElectionGuard
 
             // GetNonce is not provided
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_crypto_hash", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_get_crypto_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetCryptoHash(
                 SubmittedBallotHandle handle,
@@ -2771,7 +2802,7 @@ namespace ElectionGuard
 
             // CryptoHashWith is not provided
 
-            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_is_valid_encryption", 
+            [DllImport(DllName, EntryPoint = "eg_ciphertext_ballot_is_valid_encryption",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern bool IsValidEncryption(
                 SubmittedBallotHandle handle,
@@ -2781,33 +2812,33 @@ namespace ElectionGuard
 
             #endregion
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from_json", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from_json",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromJson(
                 [MarshalAs(UnmanagedType.LPStr)] string data,
                 out SubmittedBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from_bson", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from_bson",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromBson(
                 byte* data, ulong length, out SubmittedBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_from_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status FromMsgPack(
                 byte* data, ulong length, out SubmittedBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_to_json", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_to_json",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToJson(
                 SubmittedBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_to_bson", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_to_bson",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToBson(
                 SubmittedBallotHandle handle, out IntPtr data, out ulong size);
 
-            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_to_msgpack", 
+            [DllImport(DllName, EntryPoint = "eg_submitted_ballot_to_msgpack",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status ToMsgPack(
                 SubmittedBallotHandle handle, out IntPtr data, out ulong size);
@@ -2840,7 +2871,7 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_device_new", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_device_new",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
                 ulong deviceUuid,
@@ -2849,11 +2880,11 @@ namespace ElectionGuard
                 [MarshalAs(UnmanagedType.LPStr)] string location,
                 out EncryptionDeviceHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_device_free", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_device_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(EncryptionDeviceType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_device_get_hash", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_device_get_hash",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status GetHash(
                 EncryptionDeviceHandle handle,
@@ -2882,7 +2913,7 @@ namespace ElectionGuard
                 }
             }
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_new", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_new",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status New(
                 InternalManifest.InternalManifestHandle manifest,
@@ -2890,18 +2921,18 @@ namespace ElectionGuard
                 EncryptionDevice.EncryptionDeviceHandle device,
                 out EncryptionMediatorHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_free", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_free",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Free(EncryptionMediatorType* handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_compact_encrypt_ballot", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_compact_encrypt_ballot",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status CompactEncrypt(
                 EncryptionMediatorHandle handle,
                 PlaintextBallot.PlaintextBallotHandle plainutext,
                 out CompactCiphertextBallot.CompactCiphertextBallotHandle ciphertext);
 
-            [DllImport(DllName, 
+            [DllImport(DllName,
                 EntryPoint = "eg_encryption_mediator_compact_encrypt_ballot_verify_proofs",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status CompactEncryptAndVerify(
@@ -2909,15 +2940,15 @@ namespace ElectionGuard
                 PlaintextBallot.PlaintextBallotHandle plainutext,
                 out CompactCiphertextBallot.CompactCiphertextBallotHandle ciphertext);
 
-            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_encrypt_ballot", 
+            [DllImport(DllName, EntryPoint = "eg_encryption_mediator_encrypt_ballot",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Encrypt(
                 EncryptionMediatorHandle handle,
                 PlaintextBallot.PlaintextBallotHandle plainutext,
                 out CiphertextBallot.CiphertextBallotHandle ciphertext);
 
-            [DllImport(DllName, 
-                EntryPoint = "eg_encryption_mediator_encrypt_ballot_verify_proofs", 
+            [DllImport(DllName,
+                EntryPoint = "eg_encryption_mediator_encrypt_ballot_verify_proofs",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status EncryptAndVerify(
                 EncryptionMediatorHandle handle,
@@ -2949,7 +2980,7 @@ namespace ElectionGuard
             //     bool shouldVerifyProofs,
             //     out CiphertextBallot.CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encrypt_ballot", 
+            [DllImport(DllName, EntryPoint = "eg_encrypt_ballot",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Ballot(
                 PlaintextBallot.PlaintextBallotHandle plaintext,
@@ -2959,7 +2990,7 @@ namespace ElectionGuard
                 bool shouldVerifyProofs,
                 out CiphertextBallot.CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encrypt_ballot_with_nonce", 
+            [DllImport(DllName, EntryPoint = "eg_encrypt_ballot_with_nonce",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status Ballot(
                 PlaintextBallot.PlaintextBallotHandle plaintext,
@@ -2970,7 +3001,7 @@ namespace ElectionGuard
                 bool shouldVerifyProofs,
                 out CiphertextBallot.CiphertextBallotHandle handle);
 
-            [DllImport(DllName, EntryPoint = "eg_encrypt_compact_ballot", 
+            [DllImport(DllName, EntryPoint = "eg_encrypt_compact_ballot",
                 CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
             internal static extern Status CompactBallot(
                 PlaintextBallot.PlaintextBallotHandle plaintext,

--- a/src/electionguard/encrypt.cpp
+++ b/src/electionguard/encrypt.cpp
@@ -440,7 +440,7 @@ namespace electionguard
 
         // Validate Input
         if (style == nullptr) {
-            throw runtime_error("could not find a ballot style: " + ballot.getStyleId());
+            throw invalid_argument("could not find a ballot style: " + ballot.getStyleId());
         }
 
         // Generate a random seed nonce to use for the contest and selection nonce's on the ballot

--- a/src/electionguard/facades/encrypt.cpp
+++ b/src/electionguard/facades/encrypt.cpp
@@ -5,6 +5,7 @@
 
 #include <cerrno>
 #include <exception>
+#include <stdexcept>
 
 extern "C" {
 #include "electionguard/encrypt.h"
@@ -29,7 +30,9 @@ using electionguard::PlaintextBallotContest;
 using electionguard::PlaintextBallotSelection;
 using electionguard::SelectionDescription;
 
+using std::invalid_argument;
 using std::make_unique;
+using std::runtime_error;
 using std::unique_ptr;
 
 #pragma region EncryptionDevice
@@ -119,6 +122,13 @@ eg_encryption_mediator_encrypt_ballot(eg_encryption_mediator_t *handle,
 
         *out_ciphertext_handle = AS_TYPE(eg_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encryption_mediator_encrypt_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encryption_mediator_encrypt_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encryption_mediator_encrypt_ballot", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -135,6 +145,12 @@ eg_electionguard_status_t eg_encryption_mediator_compact_encrypt_ballot(
 
         *out_ciphertext_handle = AS_TYPE(eg_compact_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encryption_mediator_compact_encrypt_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encryption_mediator_compact_encrypt_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encryption_mediator_compact_encrypt_ballot", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -151,6 +167,12 @@ eg_electionguard_status_t eg_encryption_mediator_compact_encrypt_ballot_verify_p
 
         *out_ciphertext_handle = AS_TYPE(eg_compact_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encryption_mediator_compact_encrypt_ballot_verify_proofs", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encryption_mediator_compact_encrypt_ballot_verify_proofs", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encryption_mediator_compact_encrypt_ballot_verify_proofs", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -168,6 +190,12 @@ eg_encryption_mediator_encrypt_ballot_verify_proofs(eg_encryption_mediator_t *ha
 
         *out_ciphertext_handle = AS_TYPE(eg_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encryption_mediator_encrypt_ballot_verify_proofs", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encryption_mediator_encrypt_ballot_verify_proofs", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encryption_mediator_encrypt_ballot_verify_proofs", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -199,6 +227,12 @@ eg_electionguard_status_t eg_encrypt_selection(eg_plaintext_ballot_selection_t *
 
         *out_handle = AS_TYPE(eg_ciphertext_ballot_selection_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encrypt_selection", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encrypt_selection", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encrypt_selection", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -228,6 +262,12 @@ eg_electionguard_status_t eg_encrypt_contest(
 
         *out_handle = AS_TYPE(eg_ciphertext_ballot_contest_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encrypt_contest", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encrypt_contest", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encrypt_contest", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -255,6 +295,12 @@ eg_electionguard_status_t eg_encrypt_ballot(eg_plaintext_ballot_t *in_plaintext,
                                         in_should_verify_proofs);
         *out_handle = AS_TYPE(eg_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encrypt_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encrypt_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encrypt_ballot", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -278,6 +324,12 @@ eg_electionguard_status_t eg_encrypt_ballot_with_nonce(
                                         move(nonce_ptr), 0, in_should_verify_proofs);
         *out_handle = AS_TYPE(eg_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encrypt_ballot_with_nonce", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encrypt_ballot_with_nonce", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encrypt_ballot_with_nonce", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;
@@ -305,6 +357,12 @@ eg_electionguard_status_t eg_encrypt_compact_ballot(eg_plaintext_ballot_t *in_pl
                                                0, in_should_verify_proofs);
         *out_handle = AS_TYPE(eg_compact_ciphertext_ballot_t, ciphertext.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
+    } catch (const invalid_argument &e) {
+        Log::error(":eg_encrypt_compact_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT;
+    } catch (const runtime_error &e) {
+        Log::error(":eg_encrypt_compact_ballot", e);
+        return ELECTIONGUARD_STATUS_ERROR_RUNTIME_ERROR;
     } catch (const exception &e) {
         Log::error(":eg_encrypt_compact_ballot", e);
         return ELECTIONGUARD_STATUS_ERROR_BAD_ALLOC;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,15 +39,15 @@ endif()
 # Utils Library -----------------------------------------------
 
 add_library(${UTILS_PROJECT_TARGET} SHARED
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/ballot.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/ballot.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/ballot.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/election.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/election.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/election.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/manifest.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/manifest.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/mocks/manifest.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/ballot.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/ballot.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/ballot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/election.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/election.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/election.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/manifest.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/manifest.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/generators/manifest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/utils/byte_logger.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/utils/constants.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/electionguard/utils/utils.h

--- a/test/electionguard/benchmark/bench_encrypt.cpp
+++ b/test/electionguard/benchmark/bench_encrypt.cpp
@@ -1,6 +1,6 @@
-#include "../mocks/ballot.hpp"
-#include "../mocks/election.hpp"
-#include "../mocks/manifest.hpp"
+#include "../generators/ballot.hpp"
+#include "../generators/election.hpp"
+#include "../generators/manifest.hpp"
 
 #include <benchmark/benchmark.h>
 #include <electionguard/ballot.hpp>
@@ -9,7 +9,7 @@
 #include <electionguard/manifest.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 #pragma region encryptSelection

--- a/test/electionguard/generators/ballot.cpp
+++ b/test/electionguard/generators/ballot.cpp
@@ -16,7 +16,8 @@ EG_API eg_electionguard_status_t
 eg_test_ballot_mocks_get_simple_ballot_from_file(eg_plaintext_ballot_t **out_handle)
 {
     try {
-        auto election = electionguard::test::mocks::BallotGenerator::getSimpleBallotFromFile();
+        auto election =
+          electionguard::tools::generators::BallotGenerator::getSimpleBallotFromFile();
         *out_handle = AS_TYPE(eg_plaintext_ballot_t, election.release());
         return ELECTIONGUARD_STATUS_SUCCESS;
     } catch (const exception &e) {

--- a/test/electionguard/generators/ballot.h
+++ b/test/electionguard/generators/ballot.h
@@ -1,6 +1,6 @@
 /// @file ballot.h
-#ifndef __ELECTIONGUARD_CPP_TEST_MOCKS_BALLOT_H_INCLUDED__
-#define __ELECTIONGUARD_CPP_TEST_MOCKS_BALLOT_H_INCLUDED__
+#ifndef __ELECTIONGUARD_CPP_TOOLS_GENERATORS_BALLOT_H_INCLUDED__
+#define __ELECTIONGUARD_CPP_TOOLS_GENERATORS_BALLOT_H_INCLUDED__
 
 #include <electionguard/ballot.h>
 #include <electionguard/export.h>
@@ -16,4 +16,4 @@ eg_test_ballot_mocks_get_simple_ballot_from_file(eg_plaintext_ballot_t **out_han
 }
 #endif
 
-#endif /* __ELECTIONGUARD_CPP_TEST_MOCKS_BALLOT_H_INCLUDED__ */
+#endif /* __ELECTIONGUARD_CPP_TOOLS_GENERATORS_BALLOT_H_INCLUDED__ */

--- a/test/electionguard/generators/ballot.hpp
+++ b/test/electionguard/generators/ballot.hpp
@@ -1,5 +1,5 @@
-#ifndef __ELECTIONGUARD_CPP_TEST_MOCKS_BALLOT_HPP_INCLUDED__
-#define __ELECTIONGUARD_CPP_TEST_MOCKS_BALLOT_HPP_INCLUDED__
+#ifndef __ELECTIONGUARD_CPP_TOOLS_GENERATORS_BALLOT_HPP_INCLUDED__
+#define __ELECTIONGUARD_CPP_TOOLS_GENERATORS_BALLOT_HPP_INCLUDED__
 
 #include "../../../src/electionguard/random.hpp"
 
@@ -14,7 +14,7 @@
 using namespace electionguard;
 using namespace std;
 
-namespace electionguard::test::mocks
+namespace electionguard::tools::generators
 {
     class BallotGenerator
     {
@@ -97,6 +97,6 @@ namespace electionguard::test::mocks
               ballotId, manifest.getBallotStyles().at(0).get().getObjectId(), move(contests));
         }
     };
-} // namespace electionguard::test::mocks
+} // namespace electionguard::tools::generators
 
-#endif /* __ELECTIONGUARD_CPP_TEST_MOCKS_BALLOT_HPP_INCLUDED__ */
+#endif /* __ELECTIONGUARD_CPP_TOOLS_GENERATORS_BALLOT_HPP_INCLUDED__ */

--- a/test/electionguard/generators/ballot.hpp
+++ b/test/electionguard/generators/ballot.hpp
@@ -65,9 +65,6 @@ namespace electionguard::tools::generators
 
             // jsut loop through and select the necessary amount of trues
             for (const auto &description : contest.getSelections()) {
-                if (maxChoices > contest.getNumberElected()) {
-                    maxChoices = contest.getNumberElected();
-                }
                 if (choices < maxChoices) {
                     ++choices;
                     Log::debug(" " + description.get().getObjectId() + " Adding Selection: TRUE");

--- a/test/electionguard/generators/election.cpp
+++ b/test/electionguard/generators/election.cpp
@@ -22,8 +22,8 @@ EG_API eg_electionguard_status_t eg_test_election_mocks_get_fake_ciphertext_elec
         auto *manifest = AS_TYPE(Manifest, in_manifest);
         auto *publicKey = AS_TYPE(ElementModP, in_public_key);
         auto internal = make_unique<InternalManifest>(*manifest);
-        auto context =
-          electionguard::test::mocks::ElectionGenerator::getFakeContext(*internal, *publicKey);
+        auto context = electionguard::tools::generators::ElectionGenerator::getFakeContext(
+          *internal, *publicKey);
         *out_manifest = AS_TYPE(eg_internal_manifest_t, internal.release());
         *out_context = AS_TYPE(eg_ciphertext_election_context_t, context.release());
         return ELECTIONGUARD_STATUS_SUCCESS;

--- a/test/electionguard/generators/election.h
+++ b/test/electionguard/generators/election.h
@@ -1,6 +1,6 @@
 /// @file election.h
-#ifndef __ELECTIONGUARD_CPP_TEST_MOCKS_ELECTION_H_INCLUDED__
-#define __ELECTIONGUARD_CPP_TEST_MOCKS_ELECTION_H_INCLUDED__
+#ifndef __ELECTIONGUARD_CPP_TOOLS_GENERATORS_ELECTION_H_INCLUDED__
+#define __ELECTIONGUARD_CPP_TOOLS_GENERATORS_ELECTION_H_INCLUDED__
 
 #include <electionguard/election.h>
 #include <electionguard/export.h>
@@ -18,4 +18,4 @@ EG_API eg_electionguard_status_t eg_test_election_mocks_get_fake_ciphertext_elec
 }
 #endif
 
-#endif /* __ELECTIONGUARD_CPP_TEST_MOCKS_ELECTION_H_INCLUDED__ */
+#endif /* __ELECTIONGUARD_CPP_TOOLS_GENERATORS_ELECTION_H_INCLUDED__ */

--- a/test/electionguard/generators/election.hpp
+++ b/test/electionguard/generators/election.hpp
@@ -1,5 +1,5 @@
-#ifndef __ELECTIONGUARD_CPP_TEST_MOCKS_ELECTION_HPP_INCLUDED__
-#define __ELECTIONGUARD_CPP_TEST_MOCKS_ELECTION_HPP_INCLUDED__
+#ifndef __ELECTIONGUARD_CPP_TOOLS_GENERATORS_ELECTION_HPP_INCLUDED__
+#define __ELECTIONGUARD_CPP_TOOLS_GENERATORS_ELECTION_HPP_INCLUDED__
 
 #include <electionguard/election.hpp>
 #include <electionguard/export.h>
@@ -11,7 +11,7 @@
 using namespace electionguard;
 using namespace std;
 
-namespace electionguard::test::mocks
+namespace electionguard::tools::generators
 {
     class ElectionGenerator
     {
@@ -25,6 +25,6 @@ namespace electionguard::test::mocks
             return context;
         }
     };
-} // namespace electionguard::test::mocks
+} // namespace electionguard::tools::generators
 
-#endif /* __ELECTIONGUARD_CPP_TEST_MOCKS_ELECTION_HPP_INCLUDED__ */
+#endif /* __ELECTIONGUARD_CPP_TOOLS_GENERATORS_ELECTION_HPP_INCLUDED__ */

--- a/test/electionguard/generators/manifest.cpp
+++ b/test/electionguard/generators/manifest.cpp
@@ -16,7 +16,7 @@ EG_API eg_electionguard_status_t
 eg_test_election_mocks_get_simple_election_from_file(eg_election_manifest_t **out_handle)
 {
     try {
-        auto election = electionguard::test::mocks::ManifestGenerator::
+        auto election = electionguard::tools::generators::ManifestGenerator::
           getJeffersonCountryManifest_multipleBallotStyle_fromFile();
         *out_handle = AS_TYPE(eg_election_manifest_t, election.release());
         return ELECTIONGUARD_STATUS_SUCCESS;

--- a/test/electionguard/generators/manifest.h
+++ b/test/electionguard/generators/manifest.h
@@ -1,6 +1,6 @@
 /// @file manifest.h
-#ifndef __ELECTIONGUARD_CPP_TEST_MOCKS_MAANIFEST_H_INCLUDED__
-#define __ELECTIONGUARD_CPP_TEST_MOCKS_MAANIFEST_H_INCLUDED__
+#ifndef __ELECTIONGUARD_CPP_TOOLS_GENERATORS_MAANIFEST_H_INCLUDED__
+#define __ELECTIONGUARD_CPP_TOOLS_GENERATORS_MAANIFEST_H_INCLUDED__
 
 #include <electionguard/export.h>
 #include <electionguard/manifest.h>
@@ -16,4 +16,4 @@ eg_test_election_mocks_get_simple_election_from_file(eg_election_manifest_t **ou
 }
 #endif
 
-#endif /* __ELECTIONGUARD_CPP_TEST_MOCKS_MAANIFEST_H_INCLUDED__ */
+#endif /* __ELECTIONGUARD_CPP_TOOLS_GENERATORS_MAANIFEST_H_INCLUDED__ */

--- a/test/electionguard/generators/manifest.hpp
+++ b/test/electionguard/generators/manifest.hpp
@@ -1,5 +1,5 @@
-#ifndef __ELECTIONGUARD_CPP_TEST_MOCKS_MANIFEST_HPP_INCLUDED__
-#define __ELECTIONGUARD_CPP_TEST_MOCKS_MANIFEST_HPP_INCLUDED__
+#ifndef __ELECTIONGUARD_CPP_TOOLS_GENERATORS_MANIFEST_HPP_INCLUDED__
+#define __ELECTIONGUARD_CPP_TOOLS_GENERATORS_MANIFEST_HPP_INCLUDED__
 
 #include <electionguard/election.hpp>
 #include <electionguard/export.h>
@@ -11,7 +11,7 @@
 using namespace electionguard;
 using namespace std;
 
-namespace electionguard::test::mocks
+namespace electionguard::tools::generators
 {
     class ManifestGenerator
     {
@@ -149,6 +149,6 @@ namespace electionguard::test::mocks
               move(parties), move(candidates), move(contests), move(ballotStyles));
         }
     };
-} // namespace electionguard::test::mocks
+} // namespace electionguard::tools::generators
 
-#endif /* __ELECTIONGUARD_CPP_TEST_MOCKS_MANIFEST_HPP_INCLUDED__ */
+#endif /* __ELECTIONGUARD_CPP_TOOLS_GENERATORS_MANIFEST_HPP_INCLUDED__ */

--- a/test/electionguard/generators/manifest.hpp
+++ b/test/electionguard/generators/manifest.hpp
@@ -11,6 +11,14 @@
 using namespace electionguard;
 using namespace std;
 
+#ifndef TEST_SPEC_VERSION
+#    define TEST_SPEC_VERSION "0.95.0"
+#endif
+
+#ifndef TEST_USE_SAMPLE
+#    define TEST_USE_SAMPLE "hamilton-general"
+#endif
+
 namespace electionguard::tools::generators
 {
     class ManifestGenerator
@@ -18,14 +26,19 @@ namespace electionguard::tools::generators
       public:
         static unique_ptr<Manifest> getJeffersonCountryManifest_multipleBallotStyle_fromFile()
         {
-            return getSimpleManifestFromFile("election_manifest_jefferson_county.json");
+            return getManifestFromFile("election_manifest_jefferson_county.json");
         }
-        static unique_ptr<Manifest> getSimpleManifestFromFile(const string &filename)
+        static unique_ptr<Manifest> getManifestFromFile(const string &version, const string &sample)
+        {
+            return getManifestFromFile(version + "/sample/" + sample + "/manifest.json");
+        }
+        static unique_ptr<Manifest> getManifestFromFile(const string &filePath)
         {
 
             ifstream file;
-            file.open("data/" + filename);
+            file.open("data/" + filePath);
             if (!file) {
+                //Log::debug(filePath);
                 throw invalid_argument("could not find file");
             }
 

--- a/test/electionguard/test_ballot.c
+++ b/test/electionguard/test_ballot.c
@@ -1,4 +1,4 @@
-#include "mocks/ballot.h"
+#include "generators/ballot.h"
 #include "utils/utils.h"
 
 #include <assert.h>

--- a/test/electionguard/test_ballot.cpp
+++ b/test/electionguard/test_ballot.cpp
@@ -1,12 +1,12 @@
 #include "../../src/electionguard/log.hpp"
-#include "mocks/ballot.hpp"
-#include "mocks/manifest.hpp"
+#include "generators/ballot.hpp"
+#include "generators/manifest.hpp"
 
 #include <doctest/doctest.h>
 #include <electionguard/ballot.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 TEST_CASE("Plaintext Simple Ballot Is Valid")

--- a/test/electionguard/test_ballot_compact.cpp
+++ b/test/electionguard/test_ballot_compact.cpp
@@ -1,13 +1,13 @@
 #include "../../src/electionguard/log.hpp"
-#include "mocks/ballot.hpp"
-#include "mocks/manifest.hpp"
+#include "generators/ballot.hpp"
+#include "generators/manifest.hpp"
 
 #include <doctest/doctest.h>
 #include <electionguard/ballot.hpp>
 #include <electionguard/ballot_compact.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 TEST_CASE("Can serialize CompactPlaintextBallot")

--- a/test/electionguard/test_election.cpp
+++ b/test/electionguard/test_election.cpp
@@ -1,6 +1,6 @@
 #include "../../src/electionguard/log.hpp"
-#include "mocks/election.hpp"
-#include "mocks/manifest.hpp"
+#include "generators/election.hpp"
+#include "generators/manifest.hpp"
 
 #include <doctest/doctest.h>
 #include <electionguard/election.hpp>
@@ -8,7 +8,7 @@
 #include <electionguard/manifest.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 TEST_CASE("Can serialize CiphertextElectionContext")

--- a/test/electionguard/test_encrypt.c
+++ b/test/electionguard/test_encrypt.c
@@ -1,6 +1,6 @@
-#include "mocks/ballot.h"
-#include "mocks/election.h"
-#include "mocks/manifest.h"
+#include "generators/ballot.h"
+#include "generators/election.h"
+#include "generators/manifest.h"
 #include "utils/utils.h"
 
 #include <assert.h>

--- a/test/electionguard/test_encrypt.cpp
+++ b/test/electionguard/test_encrypt.cpp
@@ -1,7 +1,7 @@
 #include "../../src/electionguard/log.hpp"
-#include "mocks/ballot.hpp"
-#include "mocks/election.hpp"
-#include "mocks/manifest.hpp"
+#include "generators/ballot.hpp"
+#include "generators/election.hpp"
+#include "generators/manifest.hpp"
 
 #include <doctest/doctest.h>
 #include <electionguard/ballot.hpp>
@@ -10,7 +10,7 @@
 #include <electionguard/manifest.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 TEST_CASE("Encrypt simple selection succeeds")

--- a/test/electionguard/test_encrypt.cpp
+++ b/test/electionguard/test_encrypt.cpp
@@ -112,6 +112,22 @@ TEST_CASE("Encrypt PlaintextBallot undervote succeeds")
                                         *context->getCryptoExtendedBaseHash()) == true);
 }
 
+TEST_CASE("Encrypt PlaintextBallot overvote fails")
+{
+    auto keypair = ElGamalKeyPair::fromSecret(TWO_MOD_Q());
+    auto manifest = ManifestGenerator::getJeffersonCountyManifest_Minimal();
+    auto internal = make_unique<InternalManifest>(*manifest);
+    auto context = ElectionGenerator::getFakeContext(*internal, *keypair->getPublicKey());
+    auto device = make_unique<EncryptionDevice>(12345UL, 23456UL, 34567UL, "Location");
+
+    auto mediator = make_unique<EncryptionMediator>(*internal, *context, *device);
+
+    // Act
+    auto plaintext = BallotGenerator::getFakeBallot(*internal, 2UL);
+    Log::debug(plaintext->toJson());
+    CHECK_THROWS_AS(mediator->encrypt(*plaintext), std::exception);
+}
+
 TEST_CASE("Encrypt simple PlaintextBallot with EncryptionMediator succeeds")
 {
     auto keypair = ElGamalKeyPair::fromSecret(TWO_MOD_Q());
@@ -168,13 +184,13 @@ TEST_CASE("Encrypt simple ballot from file with mediator succeeds")
 {
     // Arrange
     auto keypair = ElGamalKeyPair::fromSecret(TWO_MOD_Q());
-    auto manifest = ManifestGenerator::getJeffersonCountryManifest_multipleBallotStyle_fromFile();
+    auto manifest = ManifestGenerator::getManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
     auto internal = make_unique<InternalManifest>(*manifest);
     auto context = ElectionGenerator::getFakeContext(*internal, *keypair->getPublicKey());
 
     auto device = make_unique<EncryptionDevice>(12345UL, 23456UL, 34567UL, "Location");
     auto mediator = make_unique<EncryptionMediator>(*internal, *context, *device);
-    auto ballot = BallotGenerator::getSimpleBallotFromFile();
+    auto ballot = BallotGenerator::getFakeBallot(*internal);
 
     // Act
     auto ciphertext = mediator->encrypt(*ballot);
@@ -188,13 +204,13 @@ TEST_CASE("Encrypt simple ballot from file succeeds")
 {
     // Arrange
     auto keypair = ElGamalKeyPair::fromSecret(TWO_MOD_Q());
-    auto manifest = ManifestGenerator::getJeffersonCountryManifest_multipleBallotStyle_fromFile();
+    auto manifest = ManifestGenerator::getManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
     auto internal = make_unique<InternalManifest>(*manifest);
     auto context = ElectionGenerator::getFakeContext(*internal, *keypair->getPublicKey());
 
     auto device = make_unique<EncryptionDevice>(12345UL, 23456UL, 34567UL, "Location");
 
-    auto ballot = BallotGenerator::getSimpleBallotFromFile();
+    auto ballot = BallotGenerator::getFakeBallot(*internal);
 
     // Act
     auto ciphertext = encryptBallot(*ballot, *internal, *context, *device->getHash(),
@@ -211,12 +227,12 @@ TEST_CASE("Encrypt simple ballot from file submitted is valid")
 {
     // Arrange
     auto keypair = ElGamalKeyPair::fromSecret(TWO_MOD_Q());
-    auto manifest = ManifestGenerator::getJeffersonCountryManifest_multipleBallotStyle_fromFile();
+    auto manifest = ManifestGenerator::getManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
     auto internal = make_unique<InternalManifest>(*manifest);
     auto context = ElectionGenerator::getFakeContext(*internal, *keypair->getPublicKey());
     auto device = make_unique<EncryptionDevice>(12345UL, 23456UL, 34567UL, "Location");
 
-    auto ballot = BallotGenerator::getSimpleBallotFromFile();
+    auto ballot = BallotGenerator::getFakeBallot(*internal);
 
     // Act
     auto ciphertext = encryptBallot(*ballot, *internal, *context, *device->getHash());

--- a/test/electionguard/test_encrypt_compact.c
+++ b/test/electionguard/test_encrypt_compact.c
@@ -1,6 +1,6 @@
-#include "mocks/ballot.h"
-#include "mocks/election.h"
-#include "mocks/manifest.h"
+#include "generators/ballot.h"
+#include "generators/election.h"
+#include "generators/manifest.h"
 #include "utils/utils.h"
 
 #include <assert.h>

--- a/test/electionguard/test_encrypt_compact.cpp
+++ b/test/electionguard/test_encrypt_compact.cpp
@@ -1,7 +1,7 @@
 #include "../../src/electionguard/log.hpp"
-#include "mocks/ballot.hpp"
-#include "mocks/election.hpp"
-#include "mocks/manifest.hpp"
+#include "generators/ballot.hpp"
+#include "generators/election.hpp"
+#include "generators/manifest.hpp"
 
 #include <doctest/doctest.h>
 #include <electionguard/ballot.hpp>
@@ -9,7 +9,7 @@
 #include <electionguard/encrypt.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 struct TestEncryptFixture {

--- a/test/electionguard/test_manifest.c
+++ b/test/electionguard/test_manifest.c
@@ -1,5 +1,5 @@
-#include "mocks/election.h"
-#include "mocks/manifest.h"
+#include "generators/election.h"
+#include "generators/manifest.h"
 #include "utils/utils.h"
 
 #include <assert.h>

--- a/test/electionguard/test_manifest.cpp
+++ b/test/electionguard/test_manifest.cpp
@@ -1,6 +1,6 @@
 #include "../../src/electionguard/log.hpp"
-#include "mocks/election.hpp"
-#include "mocks/manifest.hpp"
+#include "generators/election.hpp"
+#include "generators/manifest.hpp"
 
 #include <doctest/doctest.h>
 #include <electionguard/election.hpp>
@@ -8,7 +8,7 @@
 #include <electionguard/manifest.hpp>
 
 using namespace electionguard;
-using namespace electionguard::test::mocks;
+using namespace electionguard::tools::generators;
 using namespace std;
 
 TEST_CASE("Simple Election Is Valid")

--- a/test/electionguard/test_manifest.cpp
+++ b/test/electionguard/test_manifest.cpp
@@ -11,18 +11,17 @@ using namespace electionguard;
 using namespace electionguard::tools::generators;
 using namespace std;
 
-TEST_CASE("Simple Election Is Valid")
+TEST_CASE("Sample Manifest Is Valid")
 {
-    auto subject = ManifestGenerator::getJeffersonCountryManifest_multipleBallotStyle_fromFile();
+    auto subject = ManifestGenerator::getManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
 
-    CHECK(subject->getElectionScopeId() == "jefferson-county-primary");
     CHECK(subject->isValid() == true);
 }
 
-TEST_CASE("Can serialize Jefferson County Minimal Manifest")
+TEST_CASE("Can serialize Sample Manifest")
 {
     // Arrange
-    auto subject = ManifestGenerator::getJeffersonCountyManifest_Minimal();
+    auto subject = ManifestGenerator::getManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
     auto json = subject->toJson();
 
     Log::debug(json);
@@ -36,27 +35,10 @@ TEST_CASE("Can serialize Jefferson County Minimal Manifest")
     CHECK(result->isValid() == true);
 }
 
-TEST_CASE("Can deserialize Jefferson County Manifest from file")
+TEST_CASE("Can construct InternalManifest from Sample Manifest")
 {
     // Arrange
-    auto subject = ManifestGenerator::getJeffersonCountryManifest_multipleBallotStyle_fromFile();
-    auto json = subject->toJson();
-
-    Log::debug(json);
-
-    // Act
-    auto result = Manifest::fromJson(json);
-
-    // Assert
-    CHECK(subject->getElectionScopeId().compare(result->getElectionScopeId()) == 0);
-    CHECK(subject->crypto_hash()->toHex() == result->crypto_hash()->toHex());
-    CHECK(result->isValid() == true);
-}
-
-TEST_CASE("Can construct InternalManifest from Manifest")
-{
-    // Arrange
-    auto data = ManifestGenerator::getJeffersonCountyManifest_Minimal();
+    auto data = ManifestGenerator::getManifestFromFile(TEST_SPEC_VERSION, TEST_USE_SAMPLE);
 
     // Act
     auto result = make_unique<InternalManifest>(*data);


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #227 

### Description
do not crash when calling encrypt from c# with a ballot that has an overvote. instead, throw an exception. This PR also includes some groundwork for #183 

### Testing
1. `make test-netstandard`
