### PR TITLE
🐛 Replace console writing with exceptions

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/ElectionGuard.Encryption.Tests.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/ElectionGuard.Encryption.Tests.csproj
@@ -18,19 +18,20 @@
   </ItemGroup>
 
   <PropertyGroup Label="Library Paths">
+    <MsvcTarget>Release</MsvcTarget>
     <ElectionGuardLibs>..\..\..\..\build\libs</ElectionGuardLibs>
   </PropertyGroup>
   <ItemGroup Label="C++ Built Libraries">
-    <None Name="Windows MSVC x86" Visible="false" Include="$(ElectionGuardLibs)\msvc\Win32\src\$(Configuration)\*.dll*">
+    <None Name="Windows MSVC x86" Visible="false" Include="$(ElectionGuardLibs)\msvc\Win32\src\$(MsvcTarget)\*.dll*">
       <CopyToOutputDirectory Condition="'$(Platform)' == 'x86' AND '$(OS)' == 'Windows_NT'">Always</CopyToOutputDirectory>
     </None>
-    <None Name="Windows MSVC x64" Visible="false" Include="$(ElectionGuardLibs)\msvc\x64\src\$(Configuration)\*.dll*">
+    <None Name="Windows MSVC x64" Visible="false" Include="$(ElectionGuardLibs)\msvc\x64\src\$(MsvcTarget)\*.dll*">
       <CopyToOutputDirectory Condition="'$(Platform)' == 'x64' AND '$(OS)' == 'Windows_NT'">Always</CopyToOutputDirectory>
     </None>
-    <None Name="Non Windows x64" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(Configuration)\src\*.dll*">
+    <None Name="Non Windows x64" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(MsvcTarget)\src\*.dll*">
       <CopyToOutputDirectory Condition="'$(OS)' != 'Windows_NT'">Always</CopyToOutputDirectory>
     </None>
-    <None Name="MacOS" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(Configuration)\src\*.dylib" CopyToOutputDirectory="Always" />
-    <None Name="Linux" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(Configuration)\src\*.so" CopyToOutputDirectory="Always" />
+    <None Name="MacOS" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(MsvcTarget)\src\*.dylib" CopyToOutputDirectory="Always" />
+    <None Name="Linux" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(MsvcTarget)\src\*.so" CopyToOutputDirectory="Always" />
   </ItemGroup>
 </Project>

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/ElectionGuard.Encryption.Tests.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/ElectionGuard.Encryption.Tests.csproj
@@ -18,20 +18,19 @@
   </ItemGroup>
 
   <PropertyGroup Label="Library Paths">
-    <MsvcTarget>Release</MsvcTarget>
     <ElectionGuardLibs>..\..\..\..\build\libs</ElectionGuardLibs>
   </PropertyGroup>
   <ItemGroup Label="C++ Built Libraries">
-    <None Name="Windows MSVC x86" Visible="false" Include="$(ElectionGuardLibs)\msvc\Win32\src\$(MsvcTarget)\*.dll*">
+    <None Name="Windows MSVC x86" Visible="false" Include="$(ElectionGuardLibs)\msvc\Win32\src\$(Configuration)\*.dll*">
       <CopyToOutputDirectory Condition="'$(Platform)' == 'x86' AND '$(OS)' == 'Windows_NT'">Always</CopyToOutputDirectory>
     </None>
-    <None Name="Windows MSVC x64" Visible="false" Include="$(ElectionGuardLibs)\msvc\x64\src\$(MsvcTarget)\*.dll*">
+    <None Name="Windows MSVC x64" Visible="false" Include="$(ElectionGuardLibs)\msvc\x64\src\$(Configuration)\*.dll*">
       <CopyToOutputDirectory Condition="'$(Platform)' == 'x64' AND '$(OS)' == 'Windows_NT'">Always</CopyToOutputDirectory>
     </None>
-    <None Name="Non Windows x64" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(MsvcTarget)\src\*.dll*">
+    <None Name="Non Windows x64" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(Configuration)\src\*.dll*">
       <CopyToOutputDirectory Condition="'$(OS)' != 'Windows_NT'">Always</CopyToOutputDirectory>
     </None>
-    <None Name="MacOS" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(MsvcTarget)\src\*.dylib" CopyToOutputDirectory="Always" />
-    <None Name="Linux" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(MsvcTarget)\src\*.so" CopyToOutputDirectory="Always" />
+    <None Name="MacOS" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(Configuration)\src\*.dylib" CopyToOutputDirectory="Always" />
+    <None Name="Linux" Visible="false" Include="$(ElectionGuardLibs)\x86_64\$(Configuration)\src\*.so" CopyToOutputDirectory="Always" />
   </ItemGroup>
 </Project>

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Ballot.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Ballot.cs
@@ -3,20 +3,20 @@ using System.Runtime.InteropServices;
 
 namespace ElectionGuard
 {
+    using NativeCiphertextBallot = NativeInterface.CiphertextBallot.CiphertextBallotHandle;
+    using NativeCiphertextBallotContest = NativeInterface.CiphertextBallotContest.CiphertextBallotContestHandle;
+    using NativeCiphertextBallotSelection = NativeInterface.CiphertextBallotSelection.CiphertextBallotSelectionHandle;
+    using NativeCompactCiphertextBallot = NativeInterface.CompactCiphertextBallot.CompactCiphertextBallotHandle;
+    using NativeCompactPlaintextBallot = NativeInterface.CompactPlaintextBallot.CompactPlaintextBallotHandle;
+    using NativeConstantChaumPedersenProof = NativeInterface.ConstantChaumPedersenProof.ConstantChaumPedersenProofHandle;
+    using NativeDisjunctiveChaumPedersenProof = NativeInterface.DisjunctiveChaumPedersenProof.DisjunctiveChaumPedersenProofHandle;
     // Declare native types for convenience
     using NativeElementModQ = NativeInterface.ElementModQ.ElementModQHandle;
     using NativeElGamalCiphertext = NativeInterface.ElGamalCiphertext.ElGamalCiphertextHandle;
-    using NativeDisjunctiveChaumPedersenProof = NativeInterface.DisjunctiveChaumPedersenProof.DisjunctiveChaumPedersenProofHandle;
-    using NativeConstantChaumPedersenProof = NativeInterface.ConstantChaumPedersenProof.ConstantChaumPedersenProofHandle;
     using NativeExtendedData = NativeInterface.ExtendedData.ExtendedDataHandle;
-    using NativePlaintextBallotSelection = NativeInterface.PlaintextBallotSelection.PlaintextBallotSelectionHandle;
-    using NativeCiphertextBallotSelection = NativeInterface.CiphertextBallotSelection.CiphertextBallotSelectionHandle;
-    using NativePlaintextBallotContest = NativeInterface.PlaintextBallotContest.PlaintextBallotContestHandle;
-    using NativeCiphertextBallotContest = NativeInterface.CiphertextBallotContest.CiphertextBallotContestHandle;
     using NativePlaintextBallot = NativeInterface.PlaintextBallot.PlaintextBallotHandle;
-    using NativeCompactPlaintextBallot = NativeInterface.CompactPlaintextBallot.CompactPlaintextBallotHandle;
-    using NativeCiphertextBallot = NativeInterface.CiphertextBallot.CiphertextBallotHandle;
-    using NativeCompactCiphertextBallot = NativeInterface.CompactCiphertextBallot.CompactCiphertextBallotHandle;
+    using NativePlaintextBallotContest = NativeInterface.PlaintextBallotContest.PlaintextBallotContestHandle;
+    using NativePlaintextBallotSelection = NativeInterface.PlaintextBallotSelection.PlaintextBallotSelectionHandle;
     using NativeSubmittedBallot = NativeInterface.SubmittedBallot.SubmittedBallotHandle;
 
     /// <summary>
@@ -990,8 +990,7 @@ namespace ElectionGuard
 
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CompactPlaintextBallot Error ToMsgPack: {status}");
-                return null;
+                throw new ElectionGuardException($"CompactPlaintextBallot Error ToMsgPack: {status}");
             }
 
             if (size > int.MaxValue)

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Ballot.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Ballot.cs
@@ -911,7 +911,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"PlaintextBallot Error ToBson: size is too big");
+                throw new ElectionGuardException($"PlaintextBallot Error ToBson: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -933,7 +933,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"PlaintextBallot Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"PlaintextBallot Error ToMsgPack: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -995,7 +995,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"CompactPlaintextBallot Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"CompactPlaintextBallot Error ToMsgPack: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -1243,7 +1243,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"CiphertextBallot Error ToBson: size is too big");
+                throw new ElectionGuardException($"CiphertextBallot Error ToBson: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -1267,7 +1267,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"CiphertextBallot Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"CiphertextBallot Error ToMsgPack: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -1350,7 +1350,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"CompactCiphertextBallot Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"CompactCiphertextBallot Error ToMsgPack: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -1599,7 +1599,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"SubmittedBallot Error ToBson: size is too big");
+                throw new ElectionGuardException($"SubmittedBallot Error ToBson: size is too big");
             }
 
             var byteArray = new byte[(int)size];
@@ -1621,7 +1621,7 @@ namespace ElectionGuard
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"SubmittedBallot Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"SubmittedBallot Error ToMsgPack: size is too big");
             }
 
             var byteArray = new byte[(int)size];

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
@@ -5,7 +5,7 @@
     <Platforms>x64;x86</Platforms>
 
     <!-- Project -->
-    <RootNamespace>ElectionGuard.Encryption</RootNamespace>
+    <RootNamespace>ElectionGuard</RootNamespace>
     <AssemblyName>ElectionGuard.Encryption</AssemblyName>
     <Version>0.1.6</Version>
     <AssemblyVersion>0.1.6.0</AssemblyVersion>

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuardException.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuardException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace ElectionGuard
+{
+    /// <summary>
+    /// A custom exception class to handle messages and the status code
+    /// </summary>
+    public class ElectionGuardException : Exception
+    {
+        public Status Status { get; set; }
+
+        public ElectionGuardException() { }
+        public ElectionGuardException(string message) : base(message) { }
+        public ElectionGuardException(string message, Status code) : base(message)
+        {
+            this.Status = code;
+        }
+        public ElectionGuardException(string message, System.Exception inner) : base(message, inner) { }
+    }
+
+}

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionguardSafeHandle.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionguardSafeHandle.cs
@@ -65,8 +65,7 @@ namespace ElectionGuard
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"{nameof(T)} ERROR ReleaseHandle: {ex.Message}");
-                return false;
+                throw new ElectionGuardException($"{nameof(T)} ERROR ReleaseHandle: {ex.Message}", ex);
             }
         }
     }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Group.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Group.cs
@@ -32,9 +32,9 @@ namespace ElectionGuard
             {
                 NewNative(data);
             }
-            catch
+            catch (Exception ex)
             {
-                Console.WriteLine("construction error");
+                throw new ElectionGuardException("construction error", ex);
             }
         }
 
@@ -62,7 +62,7 @@ namespace ElectionGuard
             var status = NativeInterface.ElementModP.ToHex(Handle, out IntPtr pointer);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ToHex Error Status: {status}");
+                throw new ElectionGuardException($"ToHex Error Status: {status}");
             }
             var value = Marshal.PtrToStringAnsi(pointer);
             return value;
@@ -80,7 +80,7 @@ namespace ElectionGuard
                 var status = NativeInterface.ElementModP.New(pointer, out Handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"createNative Error Status: {status}");
+                    throw new ElectionGuardException($"createNative Error Status: {status}");
                 }
             }
         }
@@ -98,14 +98,12 @@ namespace ElectionGuard
                 var status = NativeInterface.ElementModP.GetData(Handle, &element, out ulong size);
                 if (size != MAX_SIZE)
                 {
-                    Console.WriteLine("wrong size");
-                    return null;
+                    throw new ElectionGuardException($"wrong size, expected: {MAX_SIZE} actual: {size}");
                 }
 
                 if (element == null)
                 {
-                    Console.WriteLine("element is null");
-                    return null;
+                    throw new ElectionGuardException("element is null");
                 }
 
                 for (ulong i = 0; i < MAX_SIZE; i++)
@@ -144,9 +142,9 @@ namespace ElectionGuard
             {
                 NewNative(data);
             }
-            catch
+            catch (Exception ex)
             {
-                Console.WriteLine("construction error");
+                throw new ElectionGuardException("construction error", ex);
             }
         }
 
@@ -176,7 +174,7 @@ namespace ElectionGuard
             var status = NativeInterface.ElementModQ.ToHex(Handle, out IntPtr pointer);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ToHex Error Status: {status}");
+                throw new ElectionGuardException($"ToHex Error Status: {status}");
             }
             var value = Marshal.PtrToStringAnsi(pointer);
             return value;
@@ -205,7 +203,7 @@ namespace ElectionGuard
                 var status = NativeInterface.ElementModQ.New(pointer, out Handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"createNative Error Status: {status}");
+                    throw new ElectionGuardException($"createNative Error Status: {status}");
                 }
             }
         }
@@ -223,14 +221,12 @@ namespace ElectionGuard
                 var status = NativeInterface.ElementModQ.GetData(Handle, &element, out ulong size);
                 if (size != MAX_SIZE)
                 {
-                    Console.WriteLine("wrong size");
-                    return null;
+                    throw new ElectionGuardException($"wrong size, expected: {MAX_SIZE}, actual: {size}");
                 }
 
                 if (element == null)
                 {
-                    Console.WriteLine("element is null");
-                    return null;
+                    throw new ElectionGuardException("element is null");
                 }
 
                 for (ulong i = 0; i < MAX_SIZE; i++)
@@ -258,7 +254,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.G(out NaiveElementModP handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"G Error Status: {status}");
+                    throw new ElectionGuardException($"G Error Status: {status}");
                 }
                 return new ElementModP(handle);
             }
@@ -274,7 +270,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.P(out NaiveElementModP handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"P Error Status: {status}");
+                    throw new ElectionGuardException($"P Error Status: {status}");
                 }
                 return new ElementModP(handle);
             }
@@ -290,7 +286,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.ZERO_MOD_P(out NaiveElementModP handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ZERO_MOD_P Error Status: {status}");
+                    throw new ElectionGuardException($"ZERO_MOD_P Error Status: {status}");
                 }
                 return new ElementModP(handle);
             }
@@ -306,7 +302,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.ZERO_MOD_P(out NaiveElementModP handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ONE_MOD_P Error Status: {status}");
+                    throw new ElectionGuardException($"ONE_MOD_P Error Status: {status}");
                 }
                 return new ElementModP(handle);
             }
@@ -322,7 +318,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.ZERO_MOD_P(out NaiveElementModP handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"TWO_MOD_P Error Status: {status}");
+                    throw new ElectionGuardException($"TWO_MOD_P Error Status: {status}");
                 }
                 return new ElementModP(handle);
             }
@@ -338,7 +334,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.Q(out NaiveElementModQ handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Q Error Status: {status}");
+                    throw new ElectionGuardException($"Q Error Status: {status}");
                 }
                 return new ElementModQ(handle);
             }
@@ -354,7 +350,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.ZERO_MOD_Q(out NaiveElementModQ handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ZERO_MOD_Q Error Status: {status}");
+                    throw new ElectionGuardException($"ZERO_MOD_Q Error Status: {status}");
                 }
                 return new ElementModQ(handle);
             }
@@ -370,7 +366,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.ONE_MOD_Q(out NaiveElementModQ handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ONE_MOD_Q Error Status: {status}");
+                    throw new ElectionGuardException($"ONE_MOD_Q Error Status: {status}");
                 }
                 return new ElementModQ(handle);
             }
@@ -386,7 +382,7 @@ namespace ElectionGuard
                 var status = NativeInterface.Constants.TWO_MOD_Q(out NaiveElementModQ handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"TWO_MOD_Q Error Status: {status}");
+                    throw new ElectionGuardException($"TWO_MOD_Q Error Status: {status}");
                 }
                 return new ElementModQ(handle);
             }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
@@ -38,8 +38,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"AnnotatedString Error Annotation: {status}");
-                    return null;
+                    throw new ElectionGuardException($"AnnotatedString Error Annotation: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -56,8 +55,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"AnnotatedString Error Value: {status}");
-                    return null;
+                    throw new ElectionGuardException($"AnnotatedString Error Value: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -81,7 +79,7 @@ namespace ElectionGuard
             var status = NativeInterface.AnnotatedString.New(annotation, value, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"AnnotatedString Error Status: {status}");
+                throw new ElectionGuardException($"AnnotatedString Error Status: {status}");
             }
         }
 
@@ -105,8 +103,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -134,8 +131,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Language Error Value: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Language Error Value: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -152,8 +148,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Language Error LanguageAbbreviation: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Language Error LanguageAbbreviation: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -177,7 +172,7 @@ namespace ElectionGuard
             var status = NativeInterface.Language.New(value, language, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Language Error Status: {status}");
+                throw new ElectionGuardException($"Language Error Status: {status}");
             }
         }
 
@@ -201,8 +196,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -255,7 +249,7 @@ namespace ElectionGuard
             var status = NativeInterface.InternationalizedText.New(nativeText, (ulong)nativeText.Length, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternationalizedText Error Status: {status}");
+                throw new ElectionGuardException($"InternationalizedText Error Status: {status}");
             }
         }
 
@@ -281,8 +275,7 @@ namespace ElectionGuard
                 Handle, index, out NativeLanguage value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternationalizedText Error GetTextAt: {status}");
-                return null;
+                throw new ElectionGuardException($"InternationalizedText Error GetTextAt: {status}");
             }
             return new Language(value);
         }
@@ -296,8 +289,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -373,7 +365,7 @@ namespace ElectionGuard
             var status = NativeInterface.ContactInformation.New(name, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContactInformation Error Status: {status}");
+                throw new ElectionGuardException($"ContactInformation Error Status: {status}");
             }
         }
 
@@ -400,8 +392,7 @@ namespace ElectionGuard
                 Handle, index, out IntPtr value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContactInformation Error GetAddressLineAt: {status}");
-                return null;
+                throw new ElectionGuardException($"ContactInformation Error GetAddressLineAt: {status}");
             }
             return Marshal.PtrToStringAnsi(value);
         }
@@ -415,8 +406,7 @@ namespace ElectionGuard
                 Handle, index, out NativeInternationalizedText value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContactInformation Error GetEmailLineAt: {status}");
-                return null;
+                throw new ElectionGuardException($"ContactInformation Error GetEmailLineAt: {status}");
             }
             return new InternationalizedText(value);
         }
@@ -430,8 +420,7 @@ namespace ElectionGuard
                 Handle, index, out NativeInternationalizedText value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContactInformation Error GetPhoneLineAt: {status}");
-                return null;
+                throw new ElectionGuardException($"ContactInformation Error GetPhoneLineAt: {status}");
             }
             return new InternationalizedText(value);
         }
@@ -445,8 +434,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -482,8 +470,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"GeopoliticalUnit Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"GeopoliticalUnit Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -500,8 +487,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"GeopoliticalUnit Error Name: {status}");
-                    return null;
+                    throw new ElectionGuardException($"GeopoliticalUnit Error Name: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -542,7 +528,7 @@ namespace ElectionGuard
                 objectId, name, reportingUnitType, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContactInformation Error Status: {status}");
+                throw new ElectionGuardException($"ContactInformation Error Status: {status}");
             }
         }
 
@@ -566,8 +552,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -599,8 +584,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"BallotStyle Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"BallotStyle Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -650,7 +634,7 @@ namespace ElectionGuard
             var status = NativeInterface.BallotStyle.New(objectId, gpUnitIds, (ulong)gpUnitIds.Length, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"BallotStyle Error Status: {status}");
+                throw new ElectionGuardException($"BallotStyle Error Status: {status}");
             }
         }
 
@@ -674,8 +658,7 @@ namespace ElectionGuard
                 Handle, index, out IntPtr value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"BallotStyle Error GetGeopoliticalUnitIdAt: {status}");
-                return null;
+                throw new ElectionGuardException($"BallotStyle Error GetGeopoliticalUnitIdAt: {status}");
             }
             return Marshal.PtrToStringAnsi(value);
         }
@@ -689,8 +672,7 @@ namespace ElectionGuard
                 Handle, index, out IntPtr value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"BallotStyle Error GetPartyIdAt: {status}");
-                return null;
+                throw new ElectionGuardException($"BallotStyle Error GetPartyIdAt: {status}");
             }
             return Marshal.PtrToStringAnsi(value);
         }
@@ -704,8 +686,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -735,8 +716,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Party Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Party Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -753,8 +733,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Party Error Abbreviation: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Party Error Abbreviation: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -771,8 +750,7 @@ namespace ElectionGuard
                     Handle, out NativeInternationalizedText value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Party Error Name: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Party Error Name: {status}");
                 }
                 return new InternationalizedText(value);
             }
@@ -789,8 +767,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Party Error Color: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Party Error Color: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -807,8 +784,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Party Error LogoUri: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Party Error LogoUri: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -831,7 +807,7 @@ namespace ElectionGuard
             var status = NativeInterface.Party.New(objectId, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Party Error Status: {status}");
+                throw new ElectionGuardException($"Party Error Status: {status}");
             }
         }
 
@@ -851,7 +827,7 @@ namespace ElectionGuard
                 objectId, name.Handle, abbreviation, color, logoUri, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Party Error Status: {status}");
+                throw new ElectionGuardException($"Party Error Status: {status}");
             }
         }
 
@@ -875,8 +851,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -909,8 +884,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Candidate Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Candidate Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -927,8 +901,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Candidate Error CandidateId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Candidate Error CandidateId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -945,8 +918,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Candidate Error Name: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Candidate Error Name: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -963,8 +935,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Candidate Error PartyId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Candidate Error PartyId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -981,8 +952,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Candidate Error ImageUri: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Candidate Error ImageUri: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1006,7 +976,7 @@ namespace ElectionGuard
             var status = NativeInterface.Candidate.New(objectId, isWriteIn, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Candidate Error Status: {status}");
+                throw new ElectionGuardException($"Candidate Error Status: {status}");
             }
         }
 
@@ -1022,7 +992,7 @@ namespace ElectionGuard
                 objectId, partyId, isWriteIn, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Candidate Error Status: {status}");
+                throw new ElectionGuardException($"Candidate Error Status: {status}");
             }
         }
 
@@ -1042,7 +1012,7 @@ namespace ElectionGuard
                 objectId, name.Handle, partyId, imageUri, isWriteIn, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Candidate Error Status: {status}");
+                throw new ElectionGuardException($"Candidate Error Status: {status}");
             }
         }
 
@@ -1066,8 +1036,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -1104,8 +1073,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"SelectionDescription Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"SelectionDescription Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1122,8 +1090,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"SelectionDescription Error CandidateId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"SelectionDescription Error CandidateId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1164,7 +1131,7 @@ namespace ElectionGuard
                 objectId, candidateId, sequenceOrder, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"SelectionDescription Error Status: {status}");
+                throw new ElectionGuardException($"SelectionDescription Error Status: {status}");
             }
         }
 
@@ -1188,7 +1155,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
                 return null;
             }
             return new ElementModQ(value);
@@ -1222,7 +1189,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescription Error ObjectId: {status}");
+                    throw new ElectionGuardException($"ContestDescription Error ObjectId: {status}");
                     return null;
                 }
                 return Marshal.PtrToStringAnsi(value);
@@ -1241,8 +1208,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescription Error ElectoralDistrictId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescription Error ElectoralDistrictId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1310,8 +1276,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescription Error Name: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescription Error Name: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1328,8 +1293,7 @@ namespace ElectionGuard
                     Handle, out NativeInternationalizedText value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescription Error BallotTitle: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescription Error BallotTitle: {status}");
                 }
                 return new InternationalizedText(value);
             }
@@ -1346,8 +1310,7 @@ namespace ElectionGuard
                     Handle, out NativeInternationalizedText value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescription Error BallotSubTitle: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescription Error BallotSubTitle: {status}");
                 }
                 return new InternationalizedText(value);
             }
@@ -1401,7 +1364,7 @@ namespace ElectionGuard
                 selectionPointers, (ulong)selectionPointers.LongLength, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescription Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescription Error Status: {status}");
             }
         }
 
@@ -1438,7 +1401,7 @@ namespace ElectionGuard
                 selectionPointers, (ulong)selectionPointers.LongLength, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescription Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescription Error Status: {status}");
             }
         }
 
@@ -1472,7 +1435,7 @@ namespace ElectionGuard
                 primaryPartyIds, (ulong)primaryPartyIds.LongLength, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescription Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescription Error Status: {status}");
             }
         }
 
@@ -1511,7 +1474,7 @@ namespace ElectionGuard
                 primaryPartyIds, (ulong)primaryPartyIds.LongLength, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescription Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescription Error Status: {status}");
             }
         }
 
@@ -1535,8 +1498,7 @@ namespace ElectionGuard
                 Handle, index, out NativeSelectionDescription value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescription Error GetSelectionAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"ContestDescription Error GetSelectionAtIndex: {status}");
             }
             return new SelectionDescription(value);
         }
@@ -1550,8 +1512,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -1580,8 +1541,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescriptionWithPlaceholders Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1599,8 +1559,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescriptionWithPlaceholders Error ElectoralDistrictId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error ElectoralDistrictId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1668,7 +1627,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescriptionWithPlaceholders Error Name: {status}");
+                    throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Name: {status}");
                     return null;
                 }
                 return Marshal.PtrToStringAnsi(value);
@@ -1686,8 +1645,7 @@ namespace ElectionGuard
                     Handle, out NativeInternationalizedText value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescriptionWithPlaceholders Error BallotTitle: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error BallotTitle: {status}");
                 }
                 return new InternationalizedText(value);
             }
@@ -1704,8 +1662,7 @@ namespace ElectionGuard
                     Handle, out NativeInternationalizedText value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ContestDescriptionWithPlaceholders Error BallotSubTitle: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error BallotSubTitle: {status}");
                 }
                 return new InternationalizedText(value);
             }
@@ -1781,7 +1738,7 @@ namespace ElectionGuard
                  out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Status: {status}");
             }
         }
 
@@ -1828,7 +1785,7 @@ namespace ElectionGuard
                 out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Status: {status}");
             }
         }
 
@@ -1873,7 +1830,7 @@ namespace ElectionGuard
                 out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Status: {status}");
             }
         }
 
@@ -1923,7 +1880,7 @@ namespace ElectionGuard
                 out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders Error Status: {status}");
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Status: {status}");
             }
         }
 
@@ -1947,8 +1904,7 @@ namespace ElectionGuard
                 Handle, index, out NativeSelectionDescription value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders ContestDescription GetSelectionAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders ContestDescription GetSelectionAtIndex: {status}");
             }
             return new SelectionDescription(value);
         }
@@ -1962,8 +1918,7 @@ namespace ElectionGuard
                 Handle, index, out NativeSelectionDescription value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders ContestDescription GetSelectionAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders ContestDescription GetSelectionAtIndex: {status}");
             }
             return new SelectionDescription(value);
         }
@@ -1977,8 +1932,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ContestDescriptionWithPlaceholders Error CryptoHash: {status}");
-                return null;
+                throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error CryptoHash: {status}");
             }
             return new ElementModQ(value);
         }
@@ -2013,8 +1967,7 @@ namespace ElectionGuard
                     Handle, out IntPtr value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Manifest Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Manifest Error ObjectId: {status}");
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -2127,8 +2080,7 @@ namespace ElectionGuard
                     Handle, out NativeInternationalizedText value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Manifest Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Manifest Error ObjectId: {status}");
                 }
                 return new InternationalizedText(value);
             }
@@ -2145,8 +2097,7 @@ namespace ElectionGuard
                     Handle, out NativeContactInformation value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Manifest Error ObjectId: {status}");
-                    return null;
+                    throw new ElectionGuardException($"Manifest Error ObjectId: {status}");
                 }
                 return new ContactInformation(value);
             }
@@ -2168,7 +2119,7 @@ namespace ElectionGuard
             var status = NativeInterface.Manifest.FromJson(json, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error Status: {status}");
+                throw new ElectionGuardException($"Manifest Error Status: {status}");
             }
         }
 
@@ -2186,7 +2137,7 @@ namespace ElectionGuard
                     : NativeInterface.Manifest.FromMsgPack(pointer, (ulong)data.Length, out Handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"Manifest Error Binary Ctor: {status}");
+                    throw new ElectionGuardException($"Manifest Error Binary Ctor: {status}");
                 }
             }
         }
@@ -2257,7 +2208,7 @@ namespace ElectionGuard
                  out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error Status: {status}");
+                throw new ElectionGuardException($"Manifest Error Status: {status}");
             }
         }
 
@@ -2281,8 +2232,7 @@ namespace ElectionGuard
                 Handle, index, out NativeGeopoliticalUnit value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error GetGeopoliticalUnitAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"Manifest Error GetGeopoliticalUnitAtIndex: {status}");
             }
             return new GeopoliticalUnit(value);
         }
@@ -2296,8 +2246,7 @@ namespace ElectionGuard
                 Handle, index, out NativeParty value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error GetPartyAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"Manifest Error GetPartyAtIndex: {status}");
             }
             return new Party(value);
         }
@@ -2311,8 +2260,7 @@ namespace ElectionGuard
                 Handle, index, out NativeCandidate value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error GetCandidateAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"Manifest Error GetCandidateAtIndex: {status}");
             }
             return new Candidate(value);
         }
@@ -2326,8 +2274,7 @@ namespace ElectionGuard
                 Handle, index, out NativeContestDescription value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error GetContestAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"Manifest Error GetContestAtIndex: {status}");
             }
             return new ContestDescription(value);
         }
@@ -2341,8 +2288,7 @@ namespace ElectionGuard
                 Handle, index, out NativeBallotStyle value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error GetContestAtIndex: {status}");
-                return null;
+                throw new ElectionGuardException($"Manifest Error GetContestAtIndex: {status}");
             }
             return new BallotStyle(value);
         }
@@ -2356,8 +2302,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"CryptoHash Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"CryptoHash Error Status: {status}");
             }
             return new ElementModQ(value);
         }
@@ -2380,8 +2325,7 @@ namespace ElectionGuard
                 Handle, out IntPtr pointer, out ulong size);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ToJson Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"ToJson Error Status: {status}");
             }
             var json = Marshal.PtrToStringAnsi(pointer);
             return json;
@@ -2398,13 +2342,12 @@ namespace ElectionGuard
 
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error ToBson: {status}");
-                return null;
+                throw new ElectionGuardException($"Manifest Error ToBson: {status}");
             }
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"Manifest Error ToBson: size is too big");
+                throw new ElectionGuardException($"Manifest Error ToBson: size is too big. Expected <= {int.MaxValue}, Actual: {size}.");
             }
 
             var byteArray = new byte[(int)size];
@@ -2424,13 +2367,13 @@ namespace ElectionGuard
 
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"Manifest Error ToMsgPack: {status}");
+                throw new ElectionGuardException($"Manifest Error ToMsgPack: {status}");
                 return null;
             }
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"Manifest Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"Manifest Error ToMsgPack: size is too big. Expected <= {int.MaxValue}, actual: {size}.");
             }
 
             var byteArray = new byte[(int)size];
@@ -2458,8 +2401,7 @@ namespace ElectionGuard
                     Handle, out NativeElementModQ value);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"ManifestHash Error Status: {status}");
-                    return null;
+                    throw new ElectionGuardException($"ManifestHash Error Status: {status}");
                 }
                 return new ElementModQ(value);
             }
@@ -2512,7 +2454,7 @@ namespace ElectionGuard
             var status = NativeInterface.InternalManifest.New(manifest.Handle, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error Status: {status}");
+                throw new ElectionGuardException($"InternalManifest Error Status: {status}");
             }
         }
 
@@ -2525,7 +2467,7 @@ namespace ElectionGuard
             var status = NativeInterface.InternalManifest.FromJson(json, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error Status: {status}");
+                throw new ElectionGuardException($"InternalManifest Error Status: {status}");
             }
         }
 
@@ -2543,7 +2485,7 @@ namespace ElectionGuard
                     : NativeInterface.InternalManifest.FromMsgPack(pointer, (ulong)data.Length, out Handle);
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
-                    Console.WriteLine($"InternalManifest Error Binary Ctor: {status}");
+                    throw new ElectionGuardException($"InternalManifest Error Binary Ctor: {status}");
                 }
             }
         }
@@ -2568,7 +2510,7 @@ namespace ElectionGuard
                 Handle, index, out NativeGeopoliticalUnit value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error GetGeopoliticalUnitAtIndex: {status}");
+                throw new ElectionGuardException($"InternalManifest Error GetGeopoliticalUnitAtIndex: {status}");
                 return null;
             }
             return new GeopoliticalUnit(value);
@@ -2583,7 +2525,7 @@ namespace ElectionGuard
                 Handle, index, out NativeContestDescription value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error GetContestAtIndex: {status}");
+                throw new ElectionGuardException($"InternalManifest Error GetContestAtIndex: {status}");
                 return null;
             }
             return new ContestDescription(value);
@@ -2598,7 +2540,7 @@ namespace ElectionGuard
                 Handle, index, out NativeBallotStyle value);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error GetContestAtIndex: {status}");
+                throw new ElectionGuardException($"InternalManifest Error GetContestAtIndex: {status}");
                 return null;
             }
             return new BallotStyle(value);
@@ -2613,8 +2555,7 @@ namespace ElectionGuard
                 Handle, out IntPtr pointer, out ulong size);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"ToJson Error Status: {status}");
-                return null;
+                throw new ElectionGuardException($"ToJson Error Status: {status}");
             }
             var json = Marshal.PtrToStringAnsi(pointer);
             return json;
@@ -2631,13 +2572,12 @@ namespace ElectionGuard
 
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error ToBson: {status}");
-                return null;
+                throw new ElectionGuardException($"InternalManifest Error ToBson: {status}");
             }
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"InternalManifest Error ToBson: size is too big");
+                throw new ElectionGuardException($"InternalManifest Error ToBson: size is too big. Expected <= {int.MaxValue}, actual: {size}.");
             }
 
             var byteArray = new byte[(int)size];
@@ -2657,13 +2597,12 @@ namespace ElectionGuard
 
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
-                Console.WriteLine($"InternalManifest Error ToMsgPack: {status}");
-                return null;
+                throw new ElectionGuardException($"InternalManifest Error ToMsgPack: {status}");
             }
 
             if (size > int.MaxValue)
             {
-                Console.WriteLine($"InternalManifest Error ToMsgPack: size is too big");
+                throw new ElectionGuardException($"InternalManifest Error ToMsgPack: size is too big. Expected <= {int.MaxValue}, actual: {size}.");
             }
 
             var byteArray = new byte[(int)size];

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
@@ -1156,7 +1156,6 @@ namespace ElectionGuard
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"CryptoHash Error Status: {status}");
-                return null;
             }
             return new ElementModQ(value);
         }
@@ -1190,7 +1189,6 @@ namespace ElectionGuard
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
                     throw new ElectionGuardException($"ContestDescription Error ObjectId: {status}");
-                    return null;
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -1628,7 +1626,6 @@ namespace ElectionGuard
                 if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                 {
                     throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Name: {status}");
-                    return null;
                 }
                 return Marshal.PtrToStringAnsi(value);
             }
@@ -2368,7 +2365,6 @@ namespace ElectionGuard
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"Manifest Error ToMsgPack: {status}");
-                return null;
             }
 
             if (size > int.MaxValue)
@@ -2511,7 +2507,6 @@ namespace ElectionGuard
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"InternalManifest Error GetGeopoliticalUnitAtIndex: {status}");
-                return null;
             }
             return new GeopoliticalUnit(value);
         }
@@ -2526,7 +2521,6 @@ namespace ElectionGuard
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"InternalManifest Error GetContestAtIndex: {status}");
-                return null;
             }
             return new ContestDescription(value);
         }
@@ -2541,7 +2535,6 @@ namespace ElectionGuard
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"InternalManifest Error GetContestAtIndex: {status}");
-                return null;
             }
             return new BallotStyle(value);
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/NativeInterface.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/NativeInterface.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
 
 namespace ElectionGuard
 {
@@ -330,8 +330,7 @@ namespace ElectionGuard
                     var status = LinkedList.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"LinkedList Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"LinkedList Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -395,8 +394,7 @@ namespace ElectionGuard
                     var status = ElementModP.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ElementModP Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ElementModP Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -441,8 +439,7 @@ namespace ElectionGuard
                     var status = ElementModQ.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ElementModQ Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ElementModQ Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -546,8 +543,7 @@ namespace ElectionGuard
                     var status = ElGamalKeyPair.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ElGamalKeyPair Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ElGamalKeyPair Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -591,8 +587,7 @@ namespace ElectionGuard
                     var status = ElGamalCiphertext.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ElGamalCiphertext Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ElGamalCiphertext Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -658,8 +653,7 @@ namespace ElectionGuard
                     var status = DisjunctiveChaumPedersenProof.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"DisjunctiveChaumPedersenProof Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"DisjunctiveChaumPedersenProof Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -768,8 +762,7 @@ namespace ElectionGuard
                     var status = ConstantChaumPedersenProof.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ConstantChaumPedersenProof Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ConstantChaumPedersenProof Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -843,8 +836,7 @@ namespace ElectionGuard
                     var status = AnnotatedString.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"AnnotatedString Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"AnnotatedString Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -897,8 +889,7 @@ namespace ElectionGuard
                     var status = Language.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"Language Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"Language Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -952,8 +943,7 @@ namespace ElectionGuard
                     var status = InternationalizedText.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"InternationalizedText Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"InternationalizedText Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1008,8 +998,7 @@ namespace ElectionGuard
                     var status = ContactInformation.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ContactInformation Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ContactInformation Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1093,8 +1082,7 @@ namespace ElectionGuard
                     var status = GeopoliticalUnit.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"GeopoliticalUnit Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"GeopoliticalUnit Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1161,8 +1149,7 @@ namespace ElectionGuard
                     var status = BallotStyle.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"BallotStyle Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"BallotStyle Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1241,8 +1228,7 @@ namespace ElectionGuard
                     var status = Party.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"Party Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"Party Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1318,8 +1304,7 @@ namespace ElectionGuard
                     var status = Candidate.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"Candidate Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"Candidate Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1404,8 +1389,7 @@ namespace ElectionGuard
                     var status = SelectionDescription.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"SelectionDescription Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"SelectionDescription Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1463,8 +1447,7 @@ namespace ElectionGuard
                     var status = ContestDescription.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ContestDescription Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ContestDescription Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1626,8 +1609,7 @@ namespace ElectionGuard
                     var status = ContestDescriptionWithPlaceholders.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ContestDescriptionWithPlaceholders Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ContestDescriptionWithPlaceholders Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -1840,8 +1822,7 @@ namespace ElectionGuard
                     var status = Manifest.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"Manifest Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"Manifest Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2029,8 +2010,7 @@ namespace ElectionGuard
                     var status = InternalManifest.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"InternalManifest Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"InternalManifest Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2141,8 +2121,7 @@ namespace ElectionGuard
                     var status = CiphertextElectionContext.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"CiphertextElectionContext Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"CiphertextElectionContext Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2276,8 +2255,7 @@ namespace ElectionGuard
                     var status = ExtendedData.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"ExtendedData Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"ExtendedData Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2323,8 +2301,7 @@ namespace ElectionGuard
                     var status = PlaintextBallotSelection.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"PlaintextBallotSelection Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"PlaintextBallotSelection Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2396,8 +2373,7 @@ namespace ElectionGuard
                     var status = CiphertextBallotSelection.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"CiphertextBallotSelection Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"CiphertextBallotSelection Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2493,8 +2469,7 @@ namespace ElectionGuard
                     var status = PlaintextBallotContest.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"PlaintextBallotContest Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"PlaintextBallotContest Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2555,8 +2530,7 @@ namespace ElectionGuard
                     var status = CiphertextBallotContest.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"CiphertextBallotContest Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"CiphertextBallotContest Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2671,8 +2645,7 @@ namespace ElectionGuard
                     var status = PlaintextBallot.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"PlaintextBallot Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"PlaintextBallot Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2763,8 +2736,7 @@ namespace ElectionGuard
                     var status = CompactPlaintextBallot.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"CompactPlaintextBallot Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"CompactPlaintextBallot Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2804,8 +2776,7 @@ namespace ElectionGuard
                     var status = CiphertextBallot.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"CiphertextBallot Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"CiphertextBallot Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -2949,8 +2920,7 @@ namespace ElectionGuard
                     var status = CompactCiphertextBallot.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"CompactCiphertextBallot Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"CompactCiphertextBallot Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -3000,8 +2970,7 @@ namespace ElectionGuard
                     var status = SubmittedBallot.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"SubmittedBallot Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"SubmittedBallot Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -3144,8 +3113,7 @@ namespace ElectionGuard
                     var status = EncryptionDevice.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"EncryptionDevice Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"EncryptionDevice Error Free: {status}", status);
                     }
                     return true;
                 }
@@ -3186,8 +3154,7 @@ namespace ElectionGuard
                     var status = EncryptionMediator.Free(TypedPtr);
                     if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
                     {
-                        Console.WriteLine($"EncryptionMediator Error Free: {status}");
-                        return false;
+                        throw new ElectionGuardException($"EncryptionMediator Error Free: {status}", status);
                     }
                     return true;
                 }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/NativeInterface.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/NativeInterface.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Runtime.ConstrainedExecution;
 
 namespace ElectionGuard
 {
-    internal enum Status
+    public enum Status
     {
         ELECTIONGUARD_STATUS_SUCCESS = 0,
         ELECTIONGUARD_STATUS_ERROR_INVALID_ARGUMENT,


### PR DESCRIPTION
### Issue

Fixes #243 

### Description
Replaces C# `Console.Writeline()` statements with `throw ElectionGuardException` statements for a more idiomatic C# usage experience.  

Note: this PR appears to be a refactoring, but in fact it changes behavior of a number of methods that had previously been written as "catch and continue" and will now always throw an exception.  @SteveMaier-IRT confirmed that @AddressXception is ok with these behavioral changes.

### Testing
Run the unit tests, they should pass.