### PR TITLE
Whitespacing fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-text eol=auto

--- a/.gitattributes.txt
+++ b/.gitattributes.txt
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #249 

### Description
Added a .gitattributes file to hopefully normalize white spacing

### Testing
Visually looking at the white spacing. All files should use LF line endings unless files are pulled onto a windows machine in which case they should use CRLF line endings
