### PR TITLE
Removed lock on the stopping of the precompute.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(META_PROJECT_EXPORT      "ElectionGuard")
 set(META_PROJECT_TARGET      "electionguard")
 set(META_VERSION_MAJOR       "0")
 set(META_VERSION_MINOR       "1")
-set(META_VERSION_PATCH       "6")
+set(META_VERSION_PATCH       "10")
 set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
 
 set(LIBRARY_PUBLIC_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
@@ -7,9 +7,9 @@
     <!-- Project -->
     <RootNamespace>ElectionGuard</RootNamespace>
     <AssemblyName>ElectionGuard.Encryption</AssemblyName>
-    <Version>0.1.9</Version>
-    <AssemblyVersion>0.1.9.0</AssemblyVersion>
-    <AssemblyFileVersion>0.1.9.0</AssemblyFileVersion>
+    <Version>0.1.10</Version>
+    <AssemblyVersion>0.1.10.0</AssemblyVersion>
+    <AssemblyFileVersion>0.1.10.0</AssemblyFileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <Title>ElectionGuard Encryption</Title>
     <Description>Open source implementation of ElectionGuard's ballot encryption.</Description>
     <Authors>Microsoft</Authors>
-    <PackageVersion>0.1.9</PackageVersion>
+    <PackageVersion>0.1.10</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/electionguard-cpp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/electionguard-cpp</RepositoryUrl>

--- a/src/electionguard/precompute_buffers.cpp
+++ b/src/electionguard/precompute_buffers.cpp
@@ -232,11 +232,7 @@ namespace electionguard
         } while (getInstance().quadruple_queue.size() < getInstance().max);
     }
 
-    void PrecomputeBufferContext::stop_populate()
-    {
-        std::lock_guard<std::mutex> lock(queue_lock);
-        getInstance().populate_OK = false;
-    }
+    void PrecomputeBufferContext::stop_populate() { getInstance().populate_OK = false; }
 
     uint32_t PrecomputeBufferContext::get_max_queue_size() { return getInstance().max; }
 


### PR DESCRIPTION
Added benchmark to time the stop Precompute functionality.

Fixes #266 

### Description
Removed the lock that slowed the stop down.

Added the precompute calculation to the benchmarks to see the encrypt time before and after the precompute buffer is filled with data.

### Testing
Run the .NET Standard Benchmarks to see the timing on a PC or voting equipment.
