### PR TITLE
Add support to use precomputations when computing the constant chaum …

### DIFF
--- a/include/electionguard/precompute_buffers.hpp
+++ b/include/electionguard/precompute_buffers.hpp
@@ -115,10 +115,9 @@ namespace electionguard
         unique_ptr<Triple> triple1;
         unique_ptr<Triple> triple2;
         unique_ptr<Quadruple> quad;
-        bool populated = false;
 
       public:
-        explicit TwoTriplesAndAQuadruple() { populated = false; }
+        explicit TwoTriplesAndAQuadruple() {}
         TwoTriplesAndAQuadruple(unique_ptr<Triple> in_triple1, unique_ptr<Triple> in_triple2,
                                 unique_ptr<Quadruple> in_quad);
         TwoTriplesAndAQuadruple(const TwoTriplesAndAQuadruple &other);
@@ -133,8 +132,6 @@ namespace electionguard
         unique_ptr<Triple> get_triple2() { return triple2->clone(); }
 
         unique_ptr<Quadruple> get_quad() { return quad->clone(); }
-
-        bool isPopulated() { return populated; }
 
         unique_ptr<TwoTriplesAndAQuadruple> clone();
     };

--- a/include/electionguard/precompute_buffers.hpp
+++ b/include/electionguard/precompute_buffers.hpp
@@ -226,6 +226,14 @@ namespace electionguard
         static std::unique_ptr<TwoTriplesAndAQuadruple> getTwoTriplesAndAQuadruple();
 
         /// <summary>
+        /// Get the next triple from the triple queue.
+        /// This method is called by hashedElgamalEncrypt in order to get
+        /// the precomputed value to perform the hashed elgamal encryption.
+        /// <returns>std::unique_ptr<Triple></returns>
+        /// </summary>
+        static std::unique_ptr<Triple> getTriple();
+
+        /// <summary>
         /// Empty the precomputed values queues.
         /// <returns>void</returns>
         /// </summary>
@@ -236,7 +244,7 @@ namespace electionguard
         static std::mutex queue_lock;
         bool populate_OK = false;
         std::queue<std::unique_ptr<Triple>> triple_queue;
-        std::queue<std::unique_ptr<Quadruple>> quadruple_queue;
+        std::queue<std::unique_ptr<TwoTriplesAndAQuadruple>> twoTriplesAndAQuadruple_queue;
     };
 } // namespace electionguard
 

--- a/src/electionguard/chaum_pedersen.cpp
+++ b/src/electionguard/chaum_pedersen.cpp
@@ -581,13 +581,24 @@ namespace electionguard
         auto *alpha = message.getPad();
         auto *beta = message.getData();
 
-        // Pick a random number in Q.
+        // Derive nonce from seed and the constant string below
         auto nonces = make_unique<Nonces>(seed, "constant-chaum-pedersen-proof");
-        auto u = nonces->get(0);
+        unique_ptr<ElementModQ> u;
 
         // Compute the NIZKP
-        auto a = g_pow_p(*u);      //𝑔^𝑢 mod 𝑝
-        auto b = pow_mod_p(k, *u); // 𝐾^𝑢 mod 𝑝
+        unique_ptr<ElementModP> a; //𝑔^𝑢 mod 𝑝
+        unique_ptr<ElementModP> b; // 𝐾^𝑢 mod 𝑝
+        // check if the are precompute values rather than doing the exponentiations here
+        unique_ptr<Triple> triple = PrecomputeBufferContext::getTriple();
+        if (triple != nullptr) {
+            u = triple->get_exp();
+            a = triple->get_g_to_exp();
+            b = triple->get_pubkey_to_exp();
+        } else {
+            u = nonces->get(0);
+            a = g_pow_p(*u);      //𝑔^𝑢 mod 𝑝
+            b = pow_mod_p(k, *u); // 𝐾^𝑢 mod 𝑝
+        }
 
         // sha256(𝑄', A, B, a, b)
         auto c =

--- a/src/electionguard/encrypt.cpp
+++ b/src/electionguard/encrypt.cpp
@@ -234,7 +234,7 @@ namespace electionguard
     {
         unique_ptr<CiphertextBallotSelection> encrypted = NULL;
         unique_ptr<ElGamalCiphertext> ciphertext;
-        unique_ptr<TwoTriplesAndAQuadruple> precomputedTwoTriplesAndAQuad;
+        unique_ptr<TwoTriplesAndAQuadruple> precomputedTwoTriplesAndAQuad = nullptr;
 
         // Validate Input
         if (!selection.isValid(description.getObjectId())) {
@@ -256,7 +256,7 @@ namespace electionguard
         precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             auto triple1 = precomputedTwoTriplesAndAQuad->get_triple1();
             auto g_to_exp = triple1->get_g_to_exp();
             auto pubkey_to_exp = triple1->get_pubkey_to_exp();

--- a/src/electionguard/precompute_buffers.cpp
+++ b/src/electionguard/precompute_buffers.cpp
@@ -144,7 +144,6 @@ namespace electionguard
         this->triple1 = move(triple1);
         this->triple2 = move(triple2);
         this->quad = move(quad);
-        populated = true;
     }
 
     TwoTriplesAndAQuadruple::TwoTriplesAndAQuadruple(const TwoTriplesAndAQuadruple &other)
@@ -259,7 +258,7 @@ namespace electionguard
 
     std::unique_ptr<TwoTriplesAndAQuadruple> PrecomputeBufferContext::getTwoTriplesAndAQuadruple()
     {
-        unique_ptr<TwoTriplesAndAQuadruple> result = make_unique<TwoTriplesAndAQuadruple>();
+        unique_ptr<TwoTriplesAndAQuadruple> result = nullptr;
 
         // take a lock while we get the triples and a quadruple
         std::lock_guard<std::mutex> lock(queue_lock);

--- a/src/electionguard/precompute_buffers.cpp
+++ b/src/electionguard/precompute_buffers.cpp
@@ -207,12 +207,12 @@ namespace electionguard
         // try 5000 and see how that works. If the vendor wanted to pass the
         // queue size in we could use that.
         // for now we just go through the loop once
+        int iteration_count = 0;
         do {
             // TODO - Can we tolerate not returning until we have finished
             // generating two triples and a quadruple?
             // If not we can get more elaborate with the populate_OK checking
             std::lock_guard<std::mutex> lock(queue_lock);
-            int iteration_count = 0;
             if (getInstance().populate_OK) {
                 // generate two triples and a quadruple
                 //

--- a/test/electionguard/benchmark/bench_precompute.cpp
+++ b/test/electionguard/benchmark/bench_precompute.cpp
@@ -46,7 +46,7 @@ BENCHMARK_DEFINE_F(ElGamalEncryptPrecomputedFixture, ElGamalEncryptPrecomputed)(
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             auto triple1 = precomputedTwoTriplesAndAQuad->get_triple1();
             auto g_to_exp = triple1->get_g_to_exp();
             auto pubkey_to_exp = triple1->get_pubkey_to_exp();
@@ -102,7 +102,7 @@ class ChaumPedersenPrecomputedFixture : public benchmark::Fixture
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             disjunctive = DisjunctiveChaumPedersenProof::make_with_precomputed(
               *message, move(precomputedTwoTriplesAndAQuad), ONE_MOD_Q(), 1);
         }
@@ -130,7 +130,7 @@ BENCHMARK_DEFINE_F(ChaumPedersenPrecomputedFixture, disjunctiveChaumPedersenPrec
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             DisjunctiveChaumPedersenProof::make_with_precomputed(
               *message, move(precomputedTwoTriplesAndAQuad), ONE_MOD_Q(), 1);
         }
@@ -147,7 +147,7 @@ BENCHMARK_DEFINE_F(ChaumPedersenPrecomputedFixture, disjunctiveChaumPedersenPrec
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             auto item = DisjunctiveChaumPedersenProofPrecomputedHarness::make_zero_with_precomputed(
               *message, move(precomputedTwoTriplesAndAQuad), ONE_MOD_Q());
         }
@@ -164,7 +164,7 @@ BENCHMARK_DEFINE_F(ChaumPedersenPrecomputedFixture, disjunctiveChaumPedersenPrec
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             auto item = DisjunctiveChaumPedersenProofPrecomputedHarness::make_one_with_precomputed(
               *message, move(precomputedTwoTriplesAndAQuad), ONE_MOD_Q());
         }
@@ -202,7 +202,7 @@ class CiphertextBallotSelectionPrecomputedFixture : public benchmark::Fixture
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             auto triple1 = precomputedTwoTriplesAndAQuad->get_triple1();
             auto g_to_exp = triple1->get_g_to_exp();
             auto pubkey_to_exp = triple1->get_pubkey_to_exp();
@@ -236,7 +236,7 @@ BENCHMARK_DEFINE_F(CiphertextBallotSelectionPrecomputedFixture,
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
         // check if we found the precomputed values needed
-        if (precomputedTwoTriplesAndAQuad->isPopulated()) {
+        if (precomputedTwoTriplesAndAQuad != nullptr) {
             auto triple1 = precomputedTwoTriplesAndAQuad->get_triple1();
             auto g_to_exp = triple1->get_g_to_exp();
             auto pubkey_to_exp = triple1->get_pubkey_to_exp();

--- a/test/electionguard/benchmark/bench_precompute.cpp
+++ b/test/electionguard/benchmark/bench_precompute.cpp
@@ -340,6 +340,7 @@ BENCHMARK_DEFINE_F(PrecomputeFixture, precomputed)
 
         auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
     }
+    PrecomputeBufferContext::empty_queues();
 }
 
 BENCHMARK_REGISTER_F(PrecomputeFixture, precomputed)
@@ -395,6 +396,7 @@ class EncryptBallotPrecomputeFixture : public benchmark::Fixture
 
 BENCHMARK_DEFINE_F(EncryptBallotPrecomputeFixture, encryptBallotPrecompute_Full_NoProofCheck)(benchmark::State &state)
 {
+    PrecomputeBufferContext::stop_populate();
     while (state.KeepRunning()) {
         auto result = encryptBallot(*ballot, *internal, *context, *device->getHash(),
                                     make_unique<ElementModQ>(*nonce), 0UL, false);

--- a/test/electionguard/test_chaum_pedersen.cpp
+++ b/test/electionguard/test_chaum_pedersen.cpp
@@ -146,13 +146,9 @@ TEST_CASE("Disjunctive CP Proof simple valid inputs generate valid proofs")
     auto precomputedTwoTriplesAndAQuad4 = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
     CHECK(precomputedTwoTriplesAndAQuad1 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad1->isPopulated() == true);
     CHECK(precomputedTwoTriplesAndAQuad2 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad2->isPopulated() == true);
     CHECK(precomputedTwoTriplesAndAQuad3 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad3->isPopulated() == true);
     CHECK(precomputedTwoTriplesAndAQuad4 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad4->isPopulated() == true);
 
     auto triple1_1 = precomputedTwoTriplesAndAQuad1->get_triple1();
     auto triple1_2 = precomputedTwoTriplesAndAQuad2->get_triple1();
@@ -214,9 +210,7 @@ TEST_CASE("Disjunctive CP Proof encryption of zero with precomputed values")
     auto precomputedTwoTriplesAndAQuad2 = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
     CHECK(precomputedTwoTriplesAndAQuad1 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad1->isPopulated() == true);
     CHECK(precomputedTwoTriplesAndAQuad2 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad2->isPopulated() == true);
 
     auto triple1_1 = precomputedTwoTriplesAndAQuad1->get_triple1();
     auto triple1_2 = precomputedTwoTriplesAndAQuad2->get_triple1();
@@ -254,9 +248,7 @@ TEST_CASE("Disjunctive CP Proof encryption of one with precomputed values")
     auto precomputedTwoTriplesAndAQuad2 = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
     CHECK(precomputedTwoTriplesAndAQuad1 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad1->isPopulated() == true);
     CHECK(precomputedTwoTriplesAndAQuad2 != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad2->isPopulated() == true);
 
     auto triple1_1 = precomputedTwoTriplesAndAQuad1->get_triple1();
     auto triple1_2 = precomputedTwoTriplesAndAQuad2->get_triple1();

--- a/test/electionguard/test_chaum_pedersen.cpp
+++ b/test/electionguard/test_chaum_pedersen.cpp
@@ -194,6 +194,7 @@ TEST_CASE("Disjunctive CP Proof simple valid inputs generate valid proofs")
           false);
     CHECK(fourthMessageOneProof->isValid(*fourthMessage, *keypair->getPublicKey(), ONE_MOD_Q()) ==
           true);
+    PrecomputeBufferContext::empty_queues();
 }
 
 TEST_CASE("Disjunctive CP Proof encryption of zero with precomputed values")
@@ -233,6 +234,7 @@ TEST_CASE("Disjunctive CP Proof encryption of zero with precomputed values")
 
     CHECK(proof->isValid(*message1, *keypair->getPublicKey(), ONE_MOD_Q()) == true);
     CHECK(badProof->isValid(*message2, *keypair->getPublicKey(), ONE_MOD_Q()) == false);
+    PrecomputeBufferContext::empty_queues();
 }
 
 TEST_CASE("Disjunctive CP Proof encryption of one with precomputed values")
@@ -272,4 +274,5 @@ TEST_CASE("Disjunctive CP Proof encryption of one with precomputed values")
 
     CHECK(proof->isValid(*message1, *keypair->getPublicKey(), ONE_MOD_Q()) == true);
     CHECK(badProof->isValid(*message2, *keypair->getPublicKey(), ONE_MOD_Q()) == false);
+    PrecomputeBufferContext::empty_queues();
 }

--- a/test/electionguard/test_elgamal.cpp
+++ b/test/electionguard/test_elgamal.cpp
@@ -83,7 +83,6 @@ TEST_CASE("elgamalEncrypt simple encrypt 0 compared with elgamalEncrypt_with_pre
     auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
     CHECK(precomputedTwoTriplesAndAQuad != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad->isPopulated() == true);
 
     auto triple1 = precomputedTwoTriplesAndAQuad->get_triple1();
 
@@ -119,7 +118,6 @@ TEST_CASE("elgamalEncrypt_with_precomputed simple encrypt 0")
     auto precomputedTwoTriplesAndAQuad = PrecomputeBufferContext::getTwoTriplesAndAQuadruple();
 
     CHECK(precomputedTwoTriplesAndAQuad != nullptr);
-    CHECK(precomputedTwoTriplesAndAQuad->isPopulated() == true);
 
     auto triple1 = precomputedTwoTriplesAndAQuad->get_triple1();
     CHECK(triple1 != nullptr);

--- a/test/electionguard/test_elgamal.cpp
+++ b/test/electionguard/test_elgamal.cpp
@@ -98,6 +98,7 @@ TEST_CASE("elgamalEncrypt simple encrypt 0 compared with elgamalEncrypt_with_pre
     CHECK((0UL == decrypted1));
     auto decrypted2 = cipherText2->decrypt(secret);
     CHECK((0UL == decrypted2));
+    PrecomputeBufferContext::empty_queues();
 }
 
 TEST_CASE("elgamalEncrypt_with_precomputed simple encrypt 0")
@@ -128,6 +129,7 @@ TEST_CASE("elgamalEncrypt_with_precomputed simple encrypt 0")
 
     auto decrypted = cipherText->decrypt(secret);
     CHECK((0UL == decrypted));
+    PrecomputeBufferContext::empty_queues();
 }
 
 TEST_CASE("elgamalEncrypt simple encrypt 1 decrypts with secret")
@@ -454,4 +456,5 @@ TEST_CASE("elgamalEncrypt_with_precomputed encrypt 1, decrypts with secret")
 
     auto decrypted = cipherText->decrypt(*secret);
     CHECK(1UL == decrypted);
+    PrecomputeBufferContext::empty_queues();
 }

--- a/test/electionguard/test_encrypt.cpp
+++ b/test/electionguard/test_encrypt.cpp
@@ -69,6 +69,8 @@ TEST_CASE("Encrypt simple selection using precomputed values succeeds")
     CHECK(result->isValidEncryption(*hashContext, *keypair->getPublicKey(), ONE_MOD_Q()) == true);
     CHECK(result->getProof()->isValid(*result->getCiphertext(), *keypair->getPublicKey(),
                                       ONE_MOD_Q()) == true);
+    // need to empty the queues because future tests don't use the same keys
+    PrecomputeBufferContext::empty_queues();
 }
 
 TEST_CASE("Encrypt simple selection malformed data fails")
@@ -118,7 +120,7 @@ TEST_CASE("Encrypt PlaintextBallot with EncryptionMediator against constructed "
     auto device = make_unique<EncryptionDevice>(12345UL, 23456UL, 34567UL, "Location");
 
     auto mediator = make_unique<EncryptionMediator>(*internal, *context, *device);
-
+  
     // Act
     auto plaintext = BallotGenerator::getFakeBallot(*internal);
     // Log::debug(plaintext->toJson());
@@ -311,14 +313,14 @@ TEST_CASE("Encrypt simple ballot from file succeeds with precomputed values")
     auto ballot = BallotGenerator::getFakeBallot(*internal);
 
     // cause a two triples and a quad to be populated
-    PrecomputeBufferContext::init(50);
+    PrecomputeBufferContext::init(100);
     PrecomputeBufferContext::populate(*keypair->getPublicKey());
     PrecomputeBufferContext::stop_populate();
     uint32_t max_precomputed_queue_size = PrecomputeBufferContext::get_max_queue_size();
     uint32_t current_precomputed_queue_size = PrecomputeBufferContext::get_current_queue_size();
 
-    CHECK(50 == max_precomputed_queue_size);
-    CHECK(50 == current_precomputed_queue_size);
+    CHECK(100 == max_precomputed_queue_size);
+    CHECK(100 == current_precomputed_queue_size);
 
     // Act
     auto ciphertext = encryptBallot(*ballot, *internal, *context, *device->getHash(),
@@ -329,4 +331,5 @@ TEST_CASE("Encrypt simple ballot from file succeeds with precomputed values")
     // Assert
     CHECK(ciphertext->isValidEncryption(*context->getManifestHash(), *keypair->getPublicKey(),
                                         *context->getCryptoExtendedBaseHash()) == true);
+    PrecomputeBufferContext::empty_queues();
 }


### PR DESCRIPTION
…pedersen proof associated with a contest.

[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #268

### Description
This change updates the ConstantChaumPedersenProof::make method to support using precomputed exponentiations when available. This required a change to the precompute code to accomodate getting precomputed values other than TwoTriplesAndAQuadruple. We now support getting only a single triple as well. Triples are populated separately but in the same loop.

### Testing
The testing for this is actually covered by existing tests. However during testing of this change it was found that leftover precomputed values in the queues did break following tests sometimes. This problem is seen when the queue was populated with one public key but then a different following test case used leftover precomputed entries but was using a different public key, this caused tests to break. In order to fix this the change was made to empty the queues at the end of each test case. Note that in real world scenarios only one public key will be used and this problem cannot arise.
