### PR TITLE
Precompute hashed elgamal

### DIFF
--- a/test/electionguard/benchmark/bench_hashed_elgamal.cpp
+++ b/test/electionguard/benchmark/bench_hashed_elgamal.cpp
@@ -4,6 +4,7 @@
 #include <electionguard/constants.h>
 #include <electionguard/elgamal.hpp>
 #include <electionguard/group.hpp>
+#include <electionguard/precompute_buffers.hpp>
 
 using namespace electionguard;
 using namespace std;
@@ -50,5 +51,58 @@ BENCHMARK_DEFINE_F(HashedElgamalEncryptFixture, HashedElGamalEncrypt)(benchmark:
 }
 
 BENCHMARK_REGISTER_F(HashedElgamalEncryptFixture, HashedElGamalEncrypt)->Unit(benchmark::kMillisecond);
+
+class HashedElgamalEncryptPrecomputeFixture : public benchmark::Fixture
+{
+  public:
+    void SetUp(const ::benchmark::State &state)
+    {
+
+        nonce = rand_q();
+        secret = ElementModQ::fromHex(a_fixed_secret);
+        keypair = ElGamalKeyPair::fromSecret(TWO_MOD_Q(), false);
+        uint64_t qwords_to_use[4] = {0x0102030405060708, 0x090a0b0c0d0e0f10, 0x1112131415161718,
+                                     0x191a1b1c1d1e1f20};
+        descriptionHash = make_unique<ElementModQ>(qwords_to_use);
+        uint8_t bytes_to_use[32] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                                    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+                                    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+                                    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20};
+        vector<uint8_t> plain(bytes_to_use, bytes_to_use + sizeof(bytes_to_use));
+        plaintext = plain;
+
+        std::unique_ptr<HashedElGamalCiphertext> HEGResult = hashedElgamalEncrypt(
+          plaintext, *nonce, *keypair->getPublicKey(), *descriptionHash, NO_PADDING);
+
+        // cause precomputed entries that will be used by the selection
+        // encryptions, that should be more than enough and on teardown
+        // the rest will be removed.
+        PrecomputeBufferContext::init(300);
+        PrecomputeBufferContext::populate(*keypair->getPublicKey());
+    }
+
+    void TearDown(const ::benchmark::State &state)
+    {
+        PrecomputeBufferContext::empty_queues(); 
+    }
+
+    unique_ptr<ElementModQ> nonce;
+    unique_ptr<ElementModQ> secret;
+    unique_ptr<ElGamalKeyPair> keypair;
+    unique_ptr<ElementModQ> descriptionHash;
+    vector<uint8_t> plaintext;
+};
+
+BENCHMARK_DEFINE_F(HashedElgamalEncryptPrecomputeFixture, HashedElGamalEncryptPrecompute)
+(benchmark::State &state)
+{
+    for (auto _ : state) {
+        hashedElgamalEncrypt(plaintext, *nonce, *keypair->getPublicKey(), *descriptionHash,
+                             NO_PADDING);
+    }
+}
+
+BENCHMARK_REGISTER_F(HashedElgamalEncryptPrecomputeFixture, HashedElGamalEncryptPrecompute)
+  ->Unit(benchmark::kMillisecond);
 
 

--- a/test/electionguard/test_elgamal.cpp
+++ b/test/electionguard/test_elgamal.cpp
@@ -429,6 +429,52 @@ TEST_CASE("HashedElGamalCiphertext encrypt failure length cases")
     CHECK(encrypt_no_pad_not_block_length_failed);
 }
 
+TEST_CASE("HashedElGamalCiphertext encrypt and decrypt string data with padding and precompute")
+{
+    uint64_t qwords_to_use[4] = {0x0102030405060708, 0x090a0b0c0d0e0f10, 0x1112131415161718,
+                                 0x191a1b1c1d1e1f20};
+
+    uint8_t bytes_to_use[32] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+                                0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20};
+
+    const auto nonce = make_unique<ElementModQ>(qwords_to_use);
+    const auto descriptionHash = make_unique<ElementModQ>(qwords_to_use);
+    const auto &secret = TWO_MOD_Q();
+    auto keypair = ElGamalKeyPair::fromSecret(secret, false);
+    auto *publicKey = keypair->getPublicKey();
+
+    std::wstring plaintext_string(L"ElectionGuard Rocks!");
+    vector<uint8_t> plaintext((uint8_t *)&plaintext_string.front(),
+                              +(uint8_t *)&plaintext_string.front() +
+                                (plaintext_string.size() * 2));
+
+    // cause precomputed entries that will be used by the selection
+    // encryptions, that should be more than enough and on teardown
+    // the rest will be removed.
+    PrecomputeBufferContext::init(3);
+    PrecomputeBufferContext::populate(*keypair->getPublicKey());
+    PrecomputeBufferContext::stop_populate();
+
+    auto HEGResult =
+      hashedElgamalEncrypt(plaintext, *nonce, *publicKey, *descriptionHash, BYTES_128);
+
+    auto pad = HEGResult->getPad();
+    unique_ptr<ElementModP> p_pad = make_unique<ElementModP>(*pad);
+    auto ciphertext = HEGResult->getData();
+    auto mac = HEGResult->getMac();
+
+    CHECK(ciphertext.size() == 128);
+
+    // now lets decrypt
+    unique_ptr<HashedElGamalCiphertext> newHEG =
+      make_unique<HashedElGamalCiphertext>(move(p_pad), HEGResult->getData(), HEGResult->getMac());
+
+    vector<uint8_t> new_plaintext = newHEG->decrypt(secret, *descriptionHash, true);
+
+    CHECK(plaintext == new_plaintext);
+    PrecomputeBufferContext::empty_queues();
+}
 
 TEST_CASE("elgamalEncrypt_with_precomputed encrypt 1, decrypts with secret")
 {
@@ -454,4 +500,5 @@ TEST_CASE("elgamalEncrypt_with_precomputed encrypt 1, decrypts with secret")
 
     auto decrypted = cipherText->decrypt(*secret);
     CHECK(1UL == decrypted);
+    PrecomputeBufferContext::empty_queues();
 }


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #261

### Description
This adds support for using precomputed exponentiations from the precompute queues when performing a hashed elgamal encryption. Instead of performing exponentiations real time the precomputed Triple is pulled from the queue and used.

### Testing
C++ tests and a benchmarking test is part of the code added with this PR.
