### PR TITLE
Lookuptable mont entries

### DIFF
--- a/src/electionguard/facades/Hacl_Bignum4096.cpp
+++ b/src/electionguard/facades/Hacl_Bignum4096.cpp
@@ -1,6 +1,7 @@
 #include "Hacl_Bignum4096.hpp"
 
 #include "../../karamel/Hacl_Bignum4096.h"
+#include "../../karamel/Hacl_GenericField64.h"
 #include "../log.hpp"
 
 using electionguard::Log;
@@ -78,6 +79,21 @@ namespace hacl
             return Hacl_Bignum4096_mod_exp_consttime_precomp(context.get(), a, bBits, b, res);
         }
         return Hacl_Bignum4096_mod_exp_vartime_precomp(context.get(), a, bBits, b, res);
+    }
+
+    void Bignum4096::to_montgomery_form(uint64_t *a, uint64_t *aM) const
+    {
+        Hacl_GenericField64_to_field(context.get(), a, aM);
+    }
+
+    void Bignum4096::from_montgomery_form(uint64_t *aM, uint64_t *a) const
+    {
+        Hacl_GenericField64_from_field(context.get(), aM, a);
+    }
+
+    void Bignum4096::montgomery_mod_mul_stay_in_mont_form(uint64_t *aM, uint64_t *bM, uint64_t *cM) const
+    {
+        Hacl_GenericField64_mul(context.get(), aM, bM, cM);
     }
 
     const Bignum4096 &CONTEXT_P()

--- a/src/electionguard/facades/Hacl_Bignum4096.hpp
+++ b/src/electionguard/facades/Hacl_Bignum4096.hpp
@@ -54,6 +54,13 @@ namespace hacl
         void modExp(uint64_t *a, uint32_t bBits, uint64_t *b, uint64_t *res,
                     bool useConstTime = false) const;
 
+        void to_montgomery_form(uint64_t *a, uint64_t *aM) const;
+
+        void from_montgomery_form(uint64_t *aM, uint64_t *a) const;
+
+        void montgomery_mod_mul_stay_in_mont_form(uint64_t *aM, uint64_t *bM,
+                                                         uint64_t *cM) const;
+
       private:
         struct handle_destructor {
             void operator()(Hacl_Bignum_MontArithmetic_bn_mont_ctx_u64 *handle) const


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #253

### Description
This change is to make the entries in the lookup table be in montgomery form. The reason is to speed up exponentiations. With the entries in montogomery form it allows us to keep multiplies with mod done with the lookup table entries in montgomery form until the full exponentiation is completed. Since the mod operation is faster in montgomery form this should increase the performance of exponentiations.

### Testing
No testing has been added for this change. The code changed is low level and is very well tested by current tests. During development the values produced by the new code were compared against old code to make sure the results were the same. In any case encryption/decryption working tells use the code is working properly.
