### PR TITLE
A plus bc mod q redo

### DIFF
--- a/src/electionguard/group.cpp
+++ b/src/electionguard/group.cpp
@@ -755,38 +755,32 @@ namespace electionguard
     unique_ptr<ElementModQ> a_plus_bc_mod_q(const ElementModQ &a, const ElementModQ &b,
                                             const ElementModQ &c)
     {
-        // since the result of b*c can be larger than Q's 256,
-        // use P's length and 4096 Hacl for rest of calculation
+        // multiply b * c and the result will be twice Q in size
+        uint64_t bc[MAX_Q_LEN * 2] = {};
+        Hacl_Bignum256_mul(const_cast<ElementModQ &>(b).get(), const_cast<ElementModQ &>(c).get(),
+                           bc);
 
-        uint64_t resultBC[MAX_P_LEN] = {}; // init to MAX_P_LEN
-        Bignum256::mul(const_cast<ElementModQ &>(b).get(), const_cast<ElementModQ &>(c).get(),
-                       static_cast<uint64_t *>(resultBC));
-
-        auto bc_as_p = make_unique<ElementModP>(resultBC, true);
-        auto a_as_p = a.toElementModP();
-
-        uint64_t a_plus_bc_result[MAX_P_LEN_DOUBLE] = {};
-        uint64_t carry =
-          Bignum4096::add(a_as_p->get(), bc_as_p->get(), static_cast<uint64_t *>(a_plus_bc_result));
-
-        // we should never overflow P space since our max size
-        // is resultBC[MAX_Q_LEN_DOUBLE] + a[MAX_Q_LEN]
-        if (carry > 0) {
-            throw overflow_error("a_plus_bc_mod_q add operation out of bounds");
-        }
-
+        // perform the mod operation on bc
+        uint64_t bc_mod_q[MAX_Q_LEN] = {};
         const auto &q = Q();
-        auto q_as_p = q.toElementModP();
-        uint64_t resModQ[MAX_P_LEN] = {};
-        bool modSuccess = Bignum4096::mod(q_as_p->get(), static_cast<uint64_t *>(a_plus_bc_result),
-                                          static_cast<uint64_t *>(resModQ));
+        bool modSuccess = Hacl_Bignum256_mod(q.get(), bc, bc_mod_q);
         if (!modSuccess) {
             throw runtime_error("a_plus_bc_mod_q mod operation failed");
         }
-        uint64_t result[MAX_Q_LEN] = {};
-        memcpy(static_cast<uint64_t *>(result), resModQ, MAX_Q_SIZE);
 
-        return make_unique<ElementModQ>(result, true);
+        uint64_t a_plus_bc[MAX_Q_LEN * 2] = {};
+        uint64_t carry =
+          Hacl_Bignum256_add(const_cast<ElementModQ &>(a).get(), bc_mod_q, a_plus_bc);
+        // put the carry in
+        a_plus_bc[MAX_Q_LEN] = carry;
+
+        uint64_t res[MAX_Q_LEN] = {};
+        modSuccess = Hacl_Bignum256_mod(q.get(), a_plus_bc, res);
+        if (!modSuccess) {
+            throw runtime_error("a_plus_bc_mod_q mod operation failed");
+        }
+
+        return make_unique<ElementModQ>(res, true);
     }
 
     unique_ptr<ElementModQ> sub_from_q(const ElementModQ &a)

--- a/src/electionguard/group.cpp
+++ b/src/electionguard/group.cpp
@@ -757,25 +757,24 @@ namespace electionguard
     {
         // multiply b * c and the result will be twice Q in size
         uint64_t bc[MAX_Q_LEN * 2] = {};
-        Hacl_Bignum256_mul(const_cast<ElementModQ &>(b).get(), const_cast<ElementModQ &>(c).get(),
-                           bc);
+        Bignum256::mul(const_cast<ElementModQ &>(b).get(), const_cast<ElementModQ &>(c).get(),
+                       bc);
 
         // perform the mod operation on bc
         uint64_t bc_mod_q[MAX_Q_LEN] = {};
         const auto &q = Q();
-        bool modSuccess = Hacl_Bignum256_mod(q.get(), bc, bc_mod_q);
+        bool modSuccess = Bignum256::mod(q.get(), bc, bc_mod_q);
         if (!modSuccess) {
             throw runtime_error("a_plus_bc_mod_q mod operation failed");
         }
 
         uint64_t a_plus_bc[MAX_Q_LEN * 2] = {};
-        uint64_t carry =
-          Hacl_Bignum256_add(const_cast<ElementModQ &>(a).get(), bc_mod_q, a_plus_bc);
+        uint64_t carry = Bignum256::add(const_cast<ElementModQ &>(a).get(), bc_mod_q, a_plus_bc);
         // put the carry in
         a_plus_bc[MAX_Q_LEN] = carry;
 
         uint64_t res[MAX_Q_LEN] = {};
-        modSuccess = Hacl_Bignum256_mod(q.get(), a_plus_bc, res);
+        modSuccess = Bignum256::mod(q.get(), a_plus_bc, res);
         if (!modSuccess) {
             throw runtime_error("a_plus_bc_mod_q mod operation failed");
         }

--- a/src/electionguard/group.cpp
+++ b/src/electionguard/group.cpp
@@ -756,7 +756,7 @@ namespace electionguard
                                             const ElementModQ &c)
     {
         // multiply b * c and the result will be twice Q in size
-        uint64_t bc[MAX_Q_LEN * 2] = {};
+        uint64_t bc[MAX_Q_LEN_DOUBLE] = {};
         Bignum256::mul(const_cast<ElementModQ &>(b).get(), const_cast<ElementModQ &>(c).get(),
                        bc);
 
@@ -768,7 +768,7 @@ namespace electionguard
             throw runtime_error("a_plus_bc_mod_q mod operation failed");
         }
 
-        uint64_t a_plus_bc[MAX_Q_LEN * 2] = {};
+        uint64_t a_plus_bc[MAX_Q_LEN_DOUBLE] = {};
         uint64_t carry = Bignum256::add(const_cast<ElementModQ &>(a).get(), bc_mod_q, a_plus_bc);
         // put the carry in
         a_plus_bc[MAX_Q_LEN] = carry;

--- a/test/electionguard/benchmark/bench_group.cpp
+++ b/test/electionguard/benchmark/bench_group.cpp
@@ -33,6 +33,11 @@ class GroupElementFixture : public benchmark::Fixture
 
         auto array_size = sizeof(LARGE_P_ARRAY_1) / sizeof(uint64_t);
         p1_vector.assign(&LARGE_P_ARRAY_1[0], &LARGE_P_ARRAY_1[array_size]);
+
+        a = rand_q();
+        b = rand_q();
+        c = rand_q();
+
     }
 
     void TearDown(const ::benchmark::State &state) {}
@@ -43,6 +48,9 @@ class GroupElementFixture : public benchmark::Fixture
     unique_ptr<ElementModQ> q1;
     unique_ptr<ElementModQ> q2;
     vector<uint64_t> p1_vector;
+    unique_ptr<ElementModQ> a;
+    unique_ptr<ElementModQ> b;
+    unique_ptr<ElementModQ> c;
 };
 
 BENCHMARK_DEFINE_F(GroupElementFixture, ElementModP_fromArray)(benchmark::State &state)
@@ -216,3 +224,12 @@ BENCHMARK_DEFINE_F(GroupElementFixture, add_mod_q_overflow)(benchmark::State &st
 }
 
 BENCHMARK_REGISTER_F(GroupElementFixture, add_mod_q_overflow)->Unit(benchmark::kMillisecond);
+
+BENCHMARK_DEFINE_F(GroupElementFixture, a_plus_bc_mod_q)(benchmark::State &state)
+{
+    for (auto _ : state) {
+        auto r = a_plus_bc_mod_q(*a, *b, *c);
+    }
+}
+
+BENCHMARK_REGISTER_F(GroupElementFixture, a_plus_bc_mod_q)->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #270

### Description
This a change to the a_plus_bc_mod_q function. The function was using 4096 bit math functions from the HACL package but it is only working on 256 bit numbers. The change is to use the 256 bit math functions from the HACL package. This function is used twice for each Chaum Pedersen proof so speeding this up, will likelly make a difference to overall performance.

### Testing
This code is low level code that is used many times during a ballot encryption so no additional testing was added. A benchmark for this function was added however.
