### PR TITLE
Fixed issue with party info having an issue serializing with null values

### DIFF
--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -213,10 +213,21 @@ namespace electionguard
     {
         // TODO: other cases
         if (j.contains("name") && !j["name"].is_null()) {
+            string abbreviation;
+            string color;
+            string logo_uri;
+            if (!j["abbreviation"].is_null()) {
+                abbreviation = j["abbreviation"].get<string>();
+            }
+            if (!j["color"].is_null()) {
+                color = j["color"].get<string>();
+            }
+            if (!j["logo_uri"].is_null()) {
+                logo_uri = j["logo_uri"].get<string>();
+            }
             return make_unique<Party>(j["object_id"].get<string>(),
-                                      internationalizedTextFromJson(j["name"]),
-                                      j["abbreviation"].get<string>(), j["color"].get<string>(),
-                                      j["logo_uri"].get<string>());
+                                      internationalizedTextFromJson(j["name"]), abbreviation, color,
+                                      logo_uri);
         }
         return make_unique<Party>(j["object_id"].get<string>());
     }

--- a/test/electionguard/test_manifest.c
+++ b/test/electionguard/test_manifest.c
@@ -12,6 +12,7 @@ bool test_simple_manifest_is_valid(void);
 bool test_can_construct_ballot_style(void);
 bool test_can_construct_internationalized_text(void);
 static bool test_can_deserialize_election_description(void);
+static bool test_can_deserialize_election_description_with_nulls(void);
 static bool test_can_construct_internal_election_description_from_election_description(void);
 static bool test_can_deserlialze_internal_election_description(void);
 
@@ -20,6 +21,7 @@ bool test_manifest(void)
     printf("\n -------- test_manifest.c --------- \n");
     return test_simple_manifest_is_valid() && test_can_construct_internationalized_text() &&
            test_can_construct_ballot_style() && test_can_deserialize_election_description() &&
+           test_can_deserialize_election_description_with_nulls() &&
            test_can_construct_internal_election_description_from_election_description() &&
            test_can_deserlialze_internal_election_description();
 }
@@ -45,6 +47,28 @@ char *election_json =
   "\"geopolitical_units\":[{\"name\":\"some-gp-unit-name\",\"object_id\":\"some-geopoltical-"
   "unit-id\",\"type\":\"unknown\"}],\"parties\":[{\"object_id\":\"some-party-id-1\"},{\"object_"
   "id\":\"some-party-id-2\"}],\"start_date\":\"2021-02-04T13:30:10Z\",\"type\":\"unknown\"}";
+
+char *election_json_no_logo =
+  "{\"ballot_styles\":[{\"geopolitical_unit_ids\":[\"some-geopoltical-unit-id\"],\"object_id\":"
+  "\"some-ballot-style-id\"}],\"candidates\":[{\"object_id\":\"some-candidate-id-1\"},{"
+  "\"object_id\":\"some-candidate-id-2\"},{\"object_id\":\"some-candidate-id-3\"}],"
+  "\"contests\":[{\"ballot_selections\":[{\"candidate_id\":\"some-candidate-id-1\",\"object_"
+  "id\":\"some-object-id-affirmative\",\"sequence_order\":0},{\"candidate_id\":\"some-"
+  "candidate-id-2\",\"object_id\":\"some-object-id-negative\",\"sequence_order\":1}],"
+  "\"electoral_district_id\":\"some-geopoltical-unit-id\",\"name\":\"some-referendum-contest-"
+  "name\",\"number_elected\":1,\"object_id\":\"some-referendum-contest-object-id\",\"sequence_"
+  "order\":0,\"vote_variation\":\"one_of_m\"},{\"ballot_selections\":[{\"candidate_id\":\"some-"
+  "candidate-id-1\",\"object_id\":\"some-object-id-candidate-1\",\"sequence_order\":0},{"
+  "\"candidate_id\":\"some-candidate-id-2\",\"object_id\":\"some-object-id-candidate-2\","
+  "\"sequence_order\":1},{\"candidate_id\":\"some-candidate-id-3\",\"object_id\":\"some-object-"
+  "id-candidate-3\",\"sequence_order\":2}],\"electoral_district_id\":\"some-geopoltical-unit-"
+  "id\",\"name\":\"some-candidate-contest-name\",\"number_elected\":2,\"object_id\":\"some-"
+  "candidate-contest-object-id\",\"sequence_order\":1,\"vote_variation\":\"one_of_m\"}],"
+  "\"election_scope_id\":\"some-scope-id\",\"end_date\":\"2021-02-04T13:30:10Z\","
+  "\"geopolitical_units\":[{\"name\":\"some-gp-unit-name\",\"object_id\":\"some-geopoltical-"
+  "unit-id\",\"type\":\"unknown\"}],\"parties\":[{\"object_id\":\"some-party-id-1\", \"logo_uri\": "
+  "null},{\"object_id\":\"some-party-id-2\"}],\"start_date\":\"2021-02-04T13:30:10Z\",\"type\":"
+  "\"unknown\"}";
 
 bool test_simple_manifest_is_valid(void)
 {
@@ -77,6 +101,30 @@ bool test_can_deserialize_election_description(void)
     // Act
     eg_election_manifest_t *result = NULL;
     if (eg_election_manifest_from_json(election_json, &result)) {
+        assert(false);
+    }
+
+    // Assert
+    char *election_scope_id;
+    if (eg_election_manifest_get_election_scope_id(result, &election_scope_id)) {
+        assert(false);
+    }
+    assert(strings_are_equal("some-scope-id", election_scope_id) == true);
+
+    // Clean Up
+    eg_election_manifest_free(result);
+
+    free(election_scope_id);
+
+    return true;
+}
+
+bool test_can_deserialize_election_description_with_nulls(void)
+{
+    printf("\n -------- test_can_deserialize_election_description_with_nulls -------- \n");
+    // Act
+    eg_election_manifest_t *result = NULL;
+    if (eg_election_manifest_from_json(election_json_no_logo, &result)) {
         assert(false);
     }
 


### PR DESCRIPTION
### Issue
*Link your PR to an issue*

Fixes #292

### Description
Added checks to create manifests with nulls in either the party abbreviation, color, or logo_uri.

### Testing
C++ unit tests can be used if a manifest is setup with a null value.
