### PR TITLE
Fix/default fix

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -35,6 +35,16 @@ namespace ElectionGuard.Encrypt.Tests
         }
 
         [Test]
+        public void Test_Can_Party()
+        {
+            // Act
+            var party = new Party("new party");
+
+            // Assert
+            Assert.IsNotNull(party.Name);
+        }
+
+        [Test]
         public void Test_Can_Construct_Ballot_style()
         {
             var gpUnitIds = new[] { "gp-unit-1", "gp-unit-2" };

--- a/include/electionguard/manifest.hpp
+++ b/include/electionguard/manifest.hpp
@@ -438,6 +438,8 @@ namespace electionguard
         explicit Party(const std::string &objectId, std::unique_ptr<InternationalizedText> name,
                        const std::string &abbreviation, const std::string &color,
                        const std::string &logoUri);
+        explicit Party(const std::string &objectId, const std::string &abbreviation,
+                       const std::string &color, const std::string &logoUri);
         ~Party();
 
         Party &operator=(Party other);
@@ -1058,8 +1060,7 @@ namespace electionguard
         static std::vector<std::unique_ptr<GeopoliticalUnit>>
         copyGeopoliticalUnits(const Manifest &description);
 
-        static std::vector<std::unique_ptr<Candidate>>
-        copyCandidates(const Manifest &description);
+        static std::vector<std::unique_ptr<Candidate>> copyCandidates(const Manifest &description);
 
         static std::vector<std::unique_ptr<BallotStyle>>
         copyBallotStyles(const Manifest &description);

--- a/src/electionguard/manifest.cpp
+++ b/src/electionguard/manifest.cpp
@@ -700,12 +700,19 @@ namespace electionguard
         string color;
         string logoUri;
 
-        explicit Impl(const string &objectId) { this->object_id = objectId; }
+        explicit Impl(const string &objectId)
+        {
+            this->object_id = objectId;
+            vector<unique_ptr<Language>> text;
+            this->name = make_unique<InternationalizedText>(move(text));
+        }
 
         explicit Impl(const string &objectId, const string &abbreviation)
             : abbreviation(abbreviation)
         {
             this->object_id = objectId;
+            vector<unique_ptr<Language>> text;
+            this->name = make_unique<InternationalizedText>(move(text));
         }
 
         explicit Impl(const string &objectId, const string &abbreviation, const string &color,
@@ -713,6 +720,8 @@ namespace electionguard
             : abbreviation(abbreviation), color(color), logoUri(logoUri)
         {
             this->object_id = objectId;
+            vector<unique_ptr<Language>> text;
+            this->name = make_unique<InternationalizedText>(move(text));
         }
 
         explicit Impl(const string &objectId, unique_ptr<InternationalizedText> name,
@@ -761,6 +770,12 @@ namespace electionguard
     Party::Party(const string &objectId, unique_ptr<InternationalizedText> name,
                  const string &abbreviation, const string &color, const string &logoUri)
         : pimpl(new Impl(objectId, move(name), abbreviation, color, logoUri))
+    {
+    }
+
+    Party::Party(const string &objectId, const string &abbreviation, const string &color,
+                 const string &logoUri)
+        : pimpl(new Impl(objectId, abbreviation, color, logoUri))
     {
     }
 
@@ -1508,7 +1523,7 @@ namespace electionguard
             if (name == nullptr) {
                 auto hash = hash_elems(
                   {electionScopeId, getElectionTypeString(type), timePointToIsoString(startDate),
-                   timePointToIsoString(endDate), nullptr, geopoliticalUnitRefs, partyRefs,
+                   timePointToIsoString(endDate), nullptr, nullptr, geopoliticalUnitRefs, partyRefs,
                    contestRefs, ballotStyleRefs});
                 Log::trace("Manifest:: NO NAME!", hash->toHex());
                 return hash;
@@ -1813,8 +1828,8 @@ namespace electionguard
              vector<unique_ptr<ContestDescriptionWithPlaceholders>> contests,
              vector<unique_ptr<BallotStyle>> ballotStyles, unique_ptr<ElementModQ> manifestHash)
             : geopoliticalUnits(move(geopoliticalUnits)), candidates(move(candidates)),
-              contests(move(contests)),
-              ballotStyles(move(ballotStyles)), manifestHash(move(manifestHash))
+              contests(move(contests)), ballotStyles(move(ballotStyles)),
+              manifestHash(move(manifestHash))
         {
         }
     };
@@ -1829,8 +1844,7 @@ namespace electionguard
       vector<unique_ptr<ContestDescriptionWithPlaceholders>> contests,
       vector<unique_ptr<BallotStyle>> ballotStyles, const ElementModQ &manifestHash)
         : pimpl(new Impl(move(geopoliticalUnits), move(candidates), move(contests),
-                         move(ballotStyles),
-                         make_unique<ElementModQ>(manifestHash)))
+                         move(ballotStyles), make_unique<ElementModQ>(manifestHash)))
     {
     }
 

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -69,8 +69,10 @@ namespace electionguard
     static unique_ptr<InternationalizedText> internationalizedTextFromJson(const json &j)
     {
         vector<unique_ptr<Language>> text;
-        for (const auto &i : j["text"]) {
-            text.push_back(languageFromJson(i));
+        if (j.contains("text")) {
+            for (const auto &i : j["text"]) {
+                text.push_back(languageFromJson(i));
+            }
         }
         return make_unique<InternationalizedText>(move(text));
     }
@@ -224,13 +226,12 @@ namespace electionguard
         if (!j["logo_uri"].is_null()) {
             logo_uri = j["logo_uri"].get<string>();
         }
+        auto name = j.contains("name") && !j["name"].is_null()
+                      ? internationalizedTextFromJson(j["name"])
+                      : internationalizedTextFromJson(json("{}"));
 
-        if (j.contains("name") && !j["name"].is_null()) {
-            return make_unique<Party>(j["object_id"].get<string>(),
-                                      internationalizedTextFromJson(j["name"]), abbreviation, color,
-                                      logo_uri);
-        }
-        return make_unique<Party>(j["object_id"].get<string>(), abbreviation, color, logo_uri);
+        return make_unique<Party>(j["object_id"].get<string>(), move(name), abbreviation, color,
+                                  logo_uri);
     }
 
     static json partiesToJson(const vector<reference_wrapper<Party>> &serializable)

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -212,24 +212,25 @@ namespace electionguard
     static unique_ptr<Party> partyFromJson(const json &j)
     {
         // TODO: other cases
+        string abbreviation;
+        string color;
+        string logo_uri;
+        if (!j["abbreviation"].is_null()) {
+            abbreviation = j["abbreviation"].get<string>();
+        }
+        if (!j["color"].is_null()) {
+            color = j["color"].get<string>();
+        }
+        if (!j["logo_uri"].is_null()) {
+            logo_uri = j["logo_uri"].get<string>();
+        }
+
         if (j.contains("name") && !j["name"].is_null()) {
-            string abbreviation;
-            string color;
-            string logo_uri;
-            if (!j["abbreviation"].is_null()) {
-                abbreviation = j["abbreviation"].get<string>();
-            }
-            if (!j["color"].is_null()) {
-                color = j["color"].get<string>();
-            }
-            if (!j["logo_uri"].is_null()) {
-                logo_uri = j["logo_uri"].get<string>();
-            }
             return make_unique<Party>(j["object_id"].get<string>(),
                                       internationalizedTextFromJson(j["name"]), abbreviation, color,
                                       logo_uri);
         }
-        return make_unique<Party>(j["object_id"].get<string>());
+        return make_unique<Party>(j["object_id"].get<string>(), abbreviation, color, logo_uri);
     }
 
     static json partiesToJson(const vector<reference_wrapper<Party>> &serializable)


### PR DESCRIPTION
### Issue
*Link your PR to an issue*

Fixes #300

### Description
Manfest hash does not match the Python created manifest has due to the default values of the InternationalizedText name field in the Party objects.

### Testing
New Unit test was created to make sure that there is always a Name object created on the party class.
