### PR TITLE
- Added checks for the election type and defaulting the VotesAllowed …

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -12,6 +12,19 @@ namespace ElectionGuard.Encrypt.Tests
     {
 
         [Test]
+        public void Test_Can_Create_Contest()
+        {
+            List<SelectionDescription> selections = new List<SelectionDescription>();
+
+            var contest = new ContestDescription("contest-id", "district-id", 1, VoteVariationType.n_of_m, 1,
+                                      "test election", selections.ToArray());
+
+            // Assert
+            Assert.AreEqual(contest.VotesAllowed, 1);
+        }
+
+
+        [Test]
         public void Test_Can_Serialize_Sample_manifest()
         {
             var subject = ManifestGenerator.GetManifestFromFile();

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
@@ -7,9 +7,9 @@
     <!-- Project -->
     <RootNamespace>ElectionGuard</RootNamespace>
     <AssemblyName>ElectionGuard.Encryption</AssemblyName>
-    <Version>0.1.13</Version>
-    <AssemblyVersion>0.1.13.0</AssemblyVersion>
-    <AssemblyFileVersion>0.1.13.0</AssemblyFileVersion>
+    <Version>0.1.14</Version>
+    <AssemblyVersion>0.1.14.0</AssemblyVersion>
+    <AssemblyFileVersion>0.1.14.0</AssemblyFileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <Title>ElectionGuard Encryption</Title>
     <Description>Open source implementation of ElectionGuard's ballot encryption.</Description>
     <Authors>Microsoft</Authors>
-    <PackageVersion>0.1.13</PackageVersion>
+    <PackageVersion>0.1.14</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/electionguard-cpp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/electionguard-cpp</RepositoryUrl>

--- a/src/electionguard/manifest.cpp
+++ b/src/electionguard/manifest.cpp
@@ -1027,7 +1027,7 @@ namespace electionguard
             this->sequenceOrder = sequenceOrder;
             this->voteVariation = voteVariation;
             this->numberElected = numberElected;
-            this->votesAllowed = 0UL;
+            this->votesAllowed = voteVariation == VoteVariationType::n_of_m ? 1UL : 0UL;
             this->primaryPartyIds = {};
         }
 
@@ -1042,7 +1042,7 @@ namespace electionguard
             this->sequenceOrder = sequenceOrder;
             this->voteVariation = voteVariation;
             this->numberElected = numberElected;
-            this->votesAllowed = 0UL;
+            this->votesAllowed = voteVariation == VoteVariationType::n_of_m ? 1UL : 0UL;
         }
 
         Impl(const string &objectId, const string &electoralDistrictId,

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -452,7 +452,8 @@ namespace electionguard
         auto elected = j["number_elected"].get<uint64_t>();
         auto allowed = j.contains("votes_allowed") && !j["votes_allowed"].is_null()
                          ? j["votes_allowed"].get<uint64_t>()
-                         : 0;
+                       : variation == VoteVariationType::n_of_m ? 1
+                                                                : 0;
         auto name = j["name"].get<string>();
         auto title = j.contains("ballot_title") && !j["ballot_title"].is_null()
                        ? internationalizedTextFromJson(j["ballot_title"])

--- a/test/electionguard/test_manifest.cpp
+++ b/test/electionguard/test_manifest.cpp
@@ -65,3 +65,16 @@ TEST_CASE("Can serialize InternalManifest")
     // Assert
     CHECK(internal->getManifestHash()->toHex() == fromJson->getManifestHash()->toHex());
 }
+
+TEST_CASE("Can construct Contest from Parameters")
+{
+    vector<std::unique_ptr<electionguard::SelectionDescription>> selections;
+
+    // Arrange
+    auto data =
+      make_unique<ContestDescription>("contest-id", "district-id", 1, VoteVariationType::n_of_m, 1,
+                                      "test election", move(selections));
+
+    // Assert
+    CHECK_EQ(data->getVotesAllowed(), 1);
+}


### PR DESCRIPTION
…value to 1 if it is an n of m election

- Added C++ and C# unit tests to make sure the value gets set to 1
- Increased the build number for a new release of nuget package

### Issue
*Link your PR to an issue*

Fixes #291 

### Description
For the constructors where the Votes_Allowed was defaulting to 0, checked the election type and set it to a default of 1 if it was an n_of_m election.

### Testing
C++ and C# unit tests added
