### PR TITLE
Fixed party name serialization

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -148,7 +148,10 @@ namespace ElectionGuard.Encrypt.Tests
                 new InternationalizedText(new[] { language }),
                 new ContactInformation("na"));
 
-            Assert.That(result.IsValid());
+            var json = result.ToJson();
+
+            Assert.IsTrue(result.IsValid());
+            Assert.IsFalse(json.Contains("\"name\":{\"text\":null"));   // check to make sure the party name serialized correctly
         }
 
     }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
@@ -7,9 +7,9 @@
     <!-- Project -->
     <RootNamespace>ElectionGuard</RootNamespace>
     <AssemblyName>ElectionGuard.Encryption</AssemblyName>
-    <Version>0.1.14</Version>
-    <AssemblyVersion>0.1.14.0</AssemblyVersion>
-    <AssemblyFileVersion>0.1.14.0</AssemblyFileVersion>
+    <Version>0.1.15</Version>
+    <AssemblyVersion>0.1.15.0</AssemblyVersion>
+    <AssemblyFileVersion>0.1.15.0</AssemblyFileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <Title>ElectionGuard Encryption</Title>
     <Description>Open source implementation of ElectionGuard's ballot encryption.</Description>
     <Authors>Microsoft</Authors>
-    <PackageVersion>0.1.14</PackageVersion>
+    <PackageVersion>0.1.15</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/electionguard-cpp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/electionguard-cpp</RepositoryUrl>

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -59,7 +59,7 @@ namespace electionguard
 
     static json internationalizedTextToJson(const InternationalizedText &serializable)
     {
-        json serialized;
+        json serialized = json::array();
         for (const auto &element : serializable.getText()) {
             serialized.push_back(languageToJson(element.get()));
         }


### PR DESCRIPTION
Added unit test to verify serialization

Fixes #308 

### Description
Whe4n a manifest is created the party name was defaulting to null and that was not usable by the Python code.

### Testing
C# unit test added.
