### PR TITLE
Setup default value for votes_allowed to match the number_elected

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -12,7 +12,7 @@ namespace ElectionGuard.Encrypt.Tests
     {
 
         [Test]
-        public void Test_Can_Create_Contest()
+        public void Test_Votes_Allowed_On_Create_Contest()
         {
             List<SelectionDescription> selections = new List<SelectionDescription>();
 

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -18,9 +18,12 @@ namespace ElectionGuard.Encrypt.Tests
 
             var contest = new ContestDescription("contest-id", "district-id", 1, VoteVariationType.n_of_m, 1,
                                       "test election", selections.ToArray());
+            var contestThreeVotes = new ContestDescription("contest-id", "district-id", 1, VoteVariationType.n_of_m, 3,
+                                      "test election", selections.ToArray());
 
             // Assert
             Assert.AreEqual(contest.VotesAllowed, 1);
+            Assert.AreEqual(contestThreeVotes.VotesAllowed, 3);
         }
 
 

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -16,14 +16,11 @@ namespace ElectionGuard.Encrypt.Tests
         {
             List<SelectionDescription> selections = new List<SelectionDescription>();
 
-            var contest = new ContestDescription("contest-id", "district-id", 1, VoteVariationType.n_of_m, 1,
-                                      "test election", selections.ToArray());
             var contestThreeVotes = new ContestDescription("contest-id", "district-id", 1, VoteVariationType.n_of_m, 3,
                                       "test election", selections.ToArray());
 
             // Assert
-            Assert.AreEqual(contest.VotesAllowed, 1);
-            Assert.AreEqual(contestThreeVotes.VotesAllowed, 3);
+            Assert.AreEqual(3, contestThreeVotes.VotesAllowed);
         }
 
 

--- a/src/electionguard/manifest.cpp
+++ b/src/electionguard/manifest.cpp
@@ -1027,7 +1027,10 @@ namespace electionguard
             this->sequenceOrder = sequenceOrder;
             this->voteVariation = voteVariation;
             this->numberElected = numberElected;
-            this->votesAllowed = voteVariation == VoteVariationType::n_of_m ? 1UL : 0UL;
+            this->votesAllowed = voteVariation == VoteVariationType::n_of_m ||
+                                     voteVariation == VoteVariationType::one_of_m
+                                   ? numberElected
+                                   : 0UL;
             this->primaryPartyIds = {};
         }
 
@@ -1042,7 +1045,10 @@ namespace electionguard
             this->sequenceOrder = sequenceOrder;
             this->voteVariation = voteVariation;
             this->numberElected = numberElected;
-            this->votesAllowed = voteVariation == VoteVariationType::n_of_m ? 1UL : 0UL;
+            this->votesAllowed = voteVariation == VoteVariationType::n_of_m ||
+                                     voteVariation == VoteVariationType::one_of_m
+                                   ? numberElected
+                                   : 0UL;
         }
 
         Impl(const string &objectId, const string &electoralDistrictId,

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -450,10 +450,12 @@ namespace electionguard
         auto sequenceOrder = j["sequence_order"].get<uint64_t>();
         auto variation = getVoteVariationType(j["vote_variation"].get<string>());
         auto elected = j["number_elected"].get<uint64_t>();
-        auto allowed = j.contains("votes_allowed") && !j["votes_allowed"].is_null()
-                         ? j["votes_allowed"].get<uint64_t>()
-                       : variation == VoteVariationType::n_of_m ? 1
-                                                                : 0;
+        auto allowed =
+          j.contains("votes_allowed") && !j["votes_allowed"].is_null()
+            ? j["votes_allowed"].get<uint64_t>()
+          : variation == VoteVariationType::n_of_m || variation == VoteVariationType::one_of_m
+            ? elected
+            : 0;
         auto name = j["name"].get<string>();
         auto title = j.contains("ballot_title") && !j["ballot_title"].is_null()
                        ? internationalizedTextFromJson(j["ballot_title"])


### PR DESCRIPTION
Create C# unit test to test various default values

### Issue
*Link your PR to an issue*

Fixes #311 

### Description
Changed the default for votes_allowed to be the number_elected for n_of_m and 1_of_m election types.

### Testing
C# Unit test added to cover the default values
