### PR TITLE
For null string values for candidate and party, set them to an empty …

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestElection.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestElection.cs
@@ -20,6 +20,36 @@ namespace ElectionGuard.Encrypt.Tests
         }
 
         [Test]
+        public void Test_Can_Create_Party()
+        {
+            var candidateName = new Language("father time", "en");
+            var candidate = new Candidate(
+                "2022-holidays",
+                new InternationalizedText(new[] { candidateName }),
+                "new-years-id",
+                null,
+                false);
+
+
+            var partyName = new Language("new years", "en");
+            var party = new ElectionGuard.Party(
+                "new-years-id",
+                new InternationalizedText(new[] { partyName }),
+                "ny",
+                null,
+                null);
+
+            // Assert
+            Assert.IsNotNull(candidate);
+            Assert.IsNotNull(party);
+        }
+
+
+
+
+
+
+        [Test]
         public void Test_Can_Deserialize_Ciphertext_Election_Context()
         {
             // Arrange

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
@@ -824,7 +824,7 @@ namespace ElectionGuard
             string abbreviation, string color, string logoUri)
         {
             var status = NativeInterface.Party.New(
-                objectId, name.Handle, abbreviation, color, logoUri, out Handle);
+                objectId, name.Handle, abbreviation, color ?? string.Empty, logoUri ?? string.Empty, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"Party Error Status: {status}");
@@ -1009,7 +1009,7 @@ namespace ElectionGuard
             string partyId, string imageUri, bool isWriteIn)
         {
             var status = NativeInterface.Candidate.New(
-                objectId, name.Handle, partyId, imageUri, isWriteIn, out Handle);
+                objectId, name.Handle, partyId, imageUri ?? string.Empty, isWriteIn, out Handle);
             if (status != Status.ELECTIONGUARD_STATUS_SUCCESS)
             {
                 throw new ElectionGuardException($"Candidate Error Status: {status}");


### PR DESCRIPTION
…string

Created C# unit test

### Issue
*Link your PR to an issue*

Fixes #310 

### Description
null strings from C# will throw exceptions in the C++ code.  There are times when null is valid in C#.

### Testing
C# unit test added.
