### PR TITLE
Change string handling to use begin and end instead of front

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestChaumPedersen.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestChaumPedersen.cs
@@ -10,13 +10,13 @@ namespace ElectionGuard.Encryption.Tests
         [Test]
         public void Test_DisjunctiveChaumPedersen()
         {
-            var nonce = Constants.ONE_MOD_Q;
+            var nonce = new ElementModQ(Constants.ONE_MOD_Q.Data);
             var keyPair = ElGamalKeyPair.FromSecret(Constants.TWO_MOD_Q);
             const ulong vote = 0UL;
             var ciphertext = Elgamal.Encrypt(vote, nonce, keyPair.PublicKey);
 
             var proof = new DisjunctiveChaumPedersenProof(
-                ciphertext, nonce, keyPair.PublicKey, Constants.ONE_MOD_Q, vote);
+                ciphertext, nonce, keyPair.PublicKey, new ElementModQ(Constants.ONE_MOD_Q.Data), vote);
 
             Assert.That(proof.IsValid(ciphertext, keyPair.PublicKey, Constants.ONE_MOD_Q));
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestElection.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestElection.cs
@@ -27,7 +27,7 @@ namespace ElectionGuard.Encrypt.Tests
                 "2022-holidays",
                 new InternationalizedText(new[] { candidateName }),
                 "new-years-id",
-                null,
+                string.Empty,
                 false);
 
 

--- a/src/electionguard/encrypt.cpp
+++ b/src/electionguard/encrypt.cpp
@@ -510,8 +510,7 @@ namespace electionguard
           make_unique<Nonces>(*sharedNonce->clone(), "constant-extended-data");
         auto extendedDataNonce = noncesForExtendedData->get(0);
 
-        vector<uint8_t> extendedData_plaintext(
-          (uint8_t *)&extendedData.front(), (uint8_t *)&extendedData.front() + extendedData.size());
+        vector<uint8_t> extendedData_plaintext(extendedData.begin(), extendedData.end());
 
         // Perform HashedElGamalCiphertext calculation
         unique_ptr<HashedElGamalCiphertext> hashedElGamal =

--- a/test/electionguard/test_encrypt.cpp
+++ b/test/electionguard/test_encrypt.cpp
@@ -141,6 +141,7 @@ TEST_CASE("Encrypt PlaintextBallot with EncryptionMediator against constructed "
     // Assert
     CHECK(ciphertext->isValidEncryption(*context->getManifestHash(), *keypair->getPublicKey(),
                                         *context->getCryptoExtendedBaseHash()) == true);
+    CHECK(ciphertext->getContests().front().get().getHashedElGamalCiphertext().get() != nullptr);
 }
 
 TEST_CASE("Encrypt PlaintextBallot undervote succeeds")
@@ -490,7 +491,6 @@ TEST_CASE("Verify placeholder flag")
     auto ciphertext = encryptBallot(*ballot, *internal, *context, *device->getHash());
 
     // Assert
-    // TODO: compare other values
     CHECK(
       ciphertext->getContests().front().get().getSelections().front().get().getIsPlaceholder() ==
       false);


### PR DESCRIPTION
Added unit test to make sure the extended data is not null

### Issue
*Link your PR to an issue*

Fixes #296 

### Description
Removed the use of string.front since it is not valid when it is called on an empty string.  Changed to using .begin and .end instead which is a more common practice.

### Testing
Added a check to make sure that the extended data was not null when the contest was not overvoted or with write-ins.
