### PR TITLE
Remove unzip command for non-existant sample-data.zip file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ endif
 	wget -O cmake/CPM.cmake https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.35.0/CPM.cmake
 	wget -O sample-data-container.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
 	unzip -o sample-data-container.zip
-	unzip -o sample-data.zip
 
 
 build:


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #320 

### Description
Remove the troubling line of code (mentioned in issue #320) that was producing the error.

### Testing
Tested `make environment` on Debian Gnu/Linux 11. The command succeeds after removing this line. 
