### PR TITLE
Adds support for making environment for arch linux and some other dis…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,7 @@ ifeq ($(OPERATING_SYSTEM),Darwin)
 endif
 ifeq ($(OPERATING_SYSTEM),Linux)
 	@echo 🐧 LINUX INSTALL
-	sudo apt install -y build-essential
-	sudo apt install -y iwyu
-	sudo apt install -y llvm
-	sudo apt install -y clang-9
-	sudo apt install -y cmake
-	sudo apt install -y lcov
-	sudo apt install -y cppcheck
-	sudo apt install -y clang-format
-	sudo apt install -y clang-tidy
-	sudo apt install -y valgrind
+	@sudo /bin/bash make-environment-linux.sh
 endif
 ifeq ($(OPERATING_SYSTEM),Windows)
 	@echo 🏁 WINDOWS INSTALL

--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ To build for iOS you need XCode installed
 
 ### Linux
 
-The automated install of dependencies is currently only supported on debian-based systems. See the makefile for more information.
+The automated install of dependencies is currently only supported on debian-based systems, Arch Linux and some Redhat-based systems. Although it is supposed to work on most of the supported Linux distributions, however the following distributions have been successfully tested:
+- Archlinux
+- Debian 11
+- Ubuntu 22.04
+- Ubuntu 20.04
+- Centos 8
+- Oracle Linux 8.6
+- Oracle Linux 9
+
 
 ### 🖥️ Windows (using MSVC)
 

--- a/make-environment-linux.sh
+++ b/make-environment-linux.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+build_iwyu() {
+    # Some distributions (e.g. centos8, oracel linux 8) don't have iwyu 
+    # in their repos so we build it from the source. 
+    git clone https://github.com/include-what-you-use/include-what-you-use.git
+    cd include-what-you-use
+    if [[ `command -v clang` ]]; then
+        local clang_version=`clang --version | grep version | cut -d' ' -f3 | cut -d'.' -f1`
+        git checkout clang_${clang_version} || die "clang_${clang_version} branch not found."
+        cd ..
+        mkdir build && cd build
+        if [[ "${clang_version}" -gt 6 ]]; then
+            cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-7 ../include-what-you-use
+        else
+            cmake -G "Unix Makefiles" -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-6.0 ../include-what-you-use
+        fi
+        test -f Makefile && make
+    fi
+}
+
+get_lcov_if_not_available() {
+    # lcov is currently not available on some repo distribution
+    # such as Oracle linux 9. Therefore, we first check if it is available 
+    # in the distribtion's repo, otherwise download it from git repo
+    # and install it locally.
+    (${1} list available | grep lcov) && return 0
+    local rpm_url=$(curl -s https://api.github.com/repos/linux-test-project/lcov/releases | \
+            grep browser_download_url | \
+            grep 'noarch.rpm' | \
+            head -n 1 | \
+            cut -d'"' -f 4);
+    local rpm_name=$(echo ${rpm_url} | rev| cut -d'/' -f 1 | rev)
+    wget -O ${rpm_name} ${rpm_url}
+    ${1} localinstall -y ${rpm_name}
+}
+
+download_and_install_epel() {
+    # we have reached here therefore it must be a rehdat 7 based distribution.
+    wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    rpm -Uvh epel-release-latest-7*.rpm
+}
+
+enable_additional_repos_on_redhat() {
+    local repo_name="powertools"
+    ${1} install -y epel-release || download_and_install_epel
+    local dist_name=$(cat /etc/os-release | grep '^NAME')
+    [[ "${dist_name}" == *"Oracle"* ]] && repo_name="ol*_codeready_builder"
+    if [[ "${1}" == "dnf" ]]; then
+        ${1} config-manager --set-enabled ${repo_name}
+    elif [[ "${1}" == "yum" ]]; then
+        yum-config-manager --enable ${repo_name}
+    fi
+}
+
+make_env_on_archlinux() {
+    pacman -Sy base-devel \
+                cmake \
+                llvm \
+                clang \
+                lcov \
+                cppcheck \
+                valgrind \
+                git \
+                --noconfirm
+    build_iwyu
+}
+
+make_env_on_redhat() {
+    local packages=(llvm llvm-devel clang clang-* cmake lcov cppcheck valgrind)
+    if [[ "${1}" == "yum" ]]; then
+        ${1} groupinstall -y "Development Tools"
+        enable_additional_repos_on_redhat ${1}
+        packages=(iwyu ${packages[@]})
+        ${1} install -y ${packages[@]}
+    elif [[ "${1}" == "dnf" ]]; then
+        ${1} group install -y "Development Tools"
+        enable_additional_repos_on_redhat ${1}
+        get_lcov_if_not_available ${1}
+        ${1} install -y ${packages[@]}
+        build_iwyu
+    fi
+}
+
+make_env_on_debian() {
+    apt install -y build-essential \
+                    iwyu \
+                    llvm \
+                    clang-* \
+                    cmake \
+                    lcov \
+                    cppcheck \
+                    valgrind
+}
+
+main() {
+    local LINUX_PACKAGE_MANAGER=''
+    # We can add more package managers for more distribution support
+    # e.g. can add zypper for opensuse. 
+    declare -a pack_mans=("dnf" "yum" "apt" "pacman") 
+    for pack_man in ${pack_mans[@]}; do 
+        if [[ `command -v ${pack_man}` ]]; then 
+            LINUX_PACKAGE_MANAGER=${pack_man} 
+            echo "Package manager found: ${pack_man}" 
+            break 
+        fi 
+    done 
+    if [[ -n "${LINUX_PACKAGE_MANAGER}" ]]; then 
+        case "${LINUX_PACKAGE_MANAGER}" in
+            "yum") make_env_on_redhat ${LINUX_PACKAGE_MANAGER};;
+            "dnf") make_env_on_redhat ${LINUX_PACKAGE_MANAGER};;
+            "apt") make_env_on_debian ;;
+            "pacman") make_env_on_archlinux ;;
+            *) ;;
+        esac 
+    else 
+        die
+    fi 
+}
+
+die() {
+    local die_msg="This Linux distribution is not supported."
+    [[ -z "${1}" ]] && echo ${die_msg} || echo ${1}
+    false
+    exit
+}
+
+main


### PR DESCRIPTION
### Issue
resolves #142 

### Description
This pull request adds support for making environment for Arch Linux and other redhat-based distributions such as Oracle Linux and CentOS.
A new script called `make-environment-linux.sh` has been added and called after https://github.com/microsoft/electionguard-cpp/blob/8f8bcb550a273c58d7336f61621b00339913d817/Makefile#L47 when Linux is detected in the Makefile. 

The following functionality is added in this pull request:

- `make-environment-linux.sh` script detects the Linux distribution based on popular package managers such as dnf, yum, apt, and pacman. More support for other distributions can be added through this method in the future e.g. zypper for OpenSuse.
- It looks for four package managers i.e. dnf, yum, apt, and pacman. If none of them is found, make process is exited with `distribution not supported` message.
- Since dnf is recommended for redhat-8 and newer distributions, the script uses it to install the required packages. 
- The added script also enables additional repos such as epel, powertools (for Centos distributions), and ol*_codeready_builder (for Oracle Linux 8/9) for installing the required packages such as ccpcheck.
- It seems that `iwyu` package is not available in the official repos for CentOS-8 and Oracle Linux 8/9 so we try to build it from the github repo.
- Similarly, it also checks for the availability of `lcov `package and if not available, the latest rpm from github repo is downloaded and installed locally.

The new additions do not break the current support for debian-based distributions but add more support for other distributions. 

### Testing
Official docker images were used to test the new feature. These include:

- Archlinux
- Debian 11
- Ubuntu 22.04
- Ubuntu 20.04
- Centos 8
- Oracle Linux 8.6
- Oracle Linux 9

I am attaching the standard output console logs [logs.zip](https://github.com/microsoft/electionguard-cpp/files/9386038/logs.zip) resulting from running `make` with this PR. 



I have also tested it on CentOS 7 and Oracle Linux 7. The `make environment` tasks work fine, but there are CMake errors that need to be looked at. 

`cmake -S . -B /root/electionguard-cpp/build/libs/x86_64/Release \
        -DCMAKE_BUILD_TYPE=Release \
        -DBUILD_SHARED_LIBS=ON \
        -DCAN_USE_VECTOR_INTRINSICS=ON \
        -DCPM_SOURCE_CACHE=/root/electionguard-cpp/.cache/CPM
CMake Error: The source directory "/root/electionguard-cpp/build/libs/x86_64/Release" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.`

Since these distributions are not the latest ones and may not be supported anymore, therefore, we can avoid their support.

