### PR TITLE
Removed the use of the size of data returned from the C++ just use no…

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Ballot.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Ballot.cs
@@ -909,7 +909,7 @@ namespace ElectionGuard
             var status = NativeInterface.PlaintextBallot.ToJson(
                 Handle, out IntPtr pointer, out ulong size);
             status.ThrowIfError();
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }
@@ -1242,7 +1242,7 @@ namespace ElectionGuard
                 : NativeInterface.CiphertextBallot.ToJson(
                 Handle, out pointer, out size);
             status.ThrowIfError();
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }
@@ -1609,7 +1609,7 @@ namespace ElectionGuard
             var status = NativeInterface.SubmittedBallot.ToJson(
                 Handle, out IntPtr pointer, out ulong size);
             status.ThrowIfError();
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Election.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Election.cs
@@ -316,7 +316,7 @@ namespace ElectionGuard
             var status = NativeInterface.CiphertextElectionContext.ToJson(
                 Handle, out IntPtr pointer, out ulong size);
             status.ThrowIfError();
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/ElectionGuard.Encryption.csproj
@@ -7,9 +7,9 @@
     <!-- Project -->
     <RootNamespace>ElectionGuard</RootNamespace>
     <AssemblyName>ElectionGuard.Encryption</AssemblyName>
-    <Version>0.1.17</Version>
-    <AssemblyVersion>0.1.17.0</AssemblyVersion>
-    <AssemblyFileVersion>0.1.17.0</AssemblyFileVersion>
+    <Version>0.1.18</Version>
+    <AssemblyVersion>0.1.18.0</AssemblyVersion>
+    <AssemblyFileVersion>0.1.18.0</AssemblyFileVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <Title>ElectionGuard Encryption</Title>
     <Description>Open source implementation of ElectionGuard's ballot encryption.</Description>
     <Authors>Microsoft</Authors>
-    <PackageVersion>0.1.17</PackageVersion>
+    <PackageVersion>0.1.18</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/electionguard-cpp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/electionguard-cpp</RepositoryUrl>

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Encrypt.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Encrypt.cs
@@ -68,7 +68,7 @@ namespace ElectionGuard
         {
             var status = NativeInterface.EncryptionDevice.ToJson(Handle, out IntPtr pointer, out ulong size);
             status.ThrowIfError();
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Group.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Group.cs
@@ -415,7 +415,7 @@ namespace ElectionGuard
             var status = NativeInterface.Constants.ToJson(
                  out IntPtr pointer, out ulong size);
             status.ThrowIfError();
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }

--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption/Manifest.cs
@@ -2454,7 +2454,7 @@ namespace ElectionGuard
             {
                 throw new ElectionGuardException($"ToJson Error Status: {status}");
             }
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }
@@ -2681,7 +2681,7 @@ namespace ElectionGuard
             {
                 throw new ElectionGuardException($"ToJson Error Status: {status}");
             }
-            var json = Marshal.PtrToStringAnsi(pointer, (int)size);
+            var json = Marshal.PtrToStringAnsi(pointer);
             NativeInterface.Memory.FreeIntPtr(pointer);
             return json;
         }


### PR DESCRIPTION
…rmal string logic.

### Issue
*Link your PR to an issue*

Fixes #330 

### Description
Removed the usage of the size of string from the C++ code and just copied it to a string directly.

### Testing
There should not be an extra 0 / null at the end of a manifest or other data type afterwards
