### PR TITLE
#334 Fix double slashes with single slashes in manifest json generation

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Tests/TestManifest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -185,6 +185,7 @@ namespace ElectionGuard.Encrypt.Tests
 
             var json = result.ToJson();
             Assert.IsTrue(json.Contains("\"value\":\"Ra\\\\u00fal\""));
+            Assert.IsTrue(json.Contains("\"value\":\"Ra\\u00fal\""));
         }
     }
 }

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <unordered_map>
+#include <regex>
 
 using electionguard::G;
 using electionguard::P;
@@ -25,6 +26,8 @@ using nlohmann::json;
 using std::make_unique;
 using std::reference_wrapper;
 using std::string;
+using std::regex;
+using std::regex_replace;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
@@ -581,7 +584,8 @@ namespace electionguard
 
             static string toJson(const electionguard::Manifest &serializable)
             {
-                return fromObject(serializable).dump();
+                auto manifestStr = fromObject(serializable).dump();
+                return regex_replace(manifestStr, regex("\\\\\\\\u"), "\\u");
             }
 
             static unique_ptr<electionguard::Manifest> fromBson(vector<uint8_t> data)

--- a/src/electionguard/serialize.hpp
+++ b/src/electionguard/serialize.hpp
@@ -585,6 +585,9 @@ namespace electionguard
             static string toJson(const electionguard::Manifest &serializable)
             {
                 auto manifestStr = fromObject(serializable).dump();
+                // special characters like ú are converted to ascii escapes in C# but then 
+                //      https://github.com/nlohmann/json has a bug where it duplicates slashes,
+                //      so this code removes the duplicates to work around the bug
                 return regex_replace(manifestStr, regex("\\\\\\\\u"), "\\u");
             }
 


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #334 

### Description
When converting a manifest to json the C# replaces unicode characters like ú with an ascii escape sequence that begins with `\u`.  However the C++ json library has a bug where it double escapes `\` characters so this provides a workaround the replacing `\\u` with `\u` in the C++.

### Testing
The unit test `Test_Unicode_CandidateNames` has been adjusted to assert the correct expected values.  If it passes then we're good.