### PR TITLE
#336 Add ability to specify which ballots should be spoiled in the CLI

### DIFF
--- a/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Cli/Encrypt/EncryptOptions.cs
+++ b/bindings/netstandard/ElectionGuard/ElectionGuard.Encryption.Cli/Encrypt/EncryptOptions.cs
@@ -14,6 +14,12 @@ internal class EncryptOptions
     [Option('b', "ballots", Required = true, HelpText = "File folder containing ballots to encrypt.")]
     public string? BallotsDir { get; set; }
 
+    [Option('d', "device", Required = true, HelpText = "Json file containing device information like launch code and location.")]
+    public string? Device { get; set; }
+
+    [Option('s', "spoiled_ids", Required = false, Separator = ',', HelpText = "Json file containing device information like launch code and location.")]
+    public IEnumerable<string> SpoiledDeviceIds { get; set; }
+
     [Option('o', "out", Required = true, HelpText = "File folder in which to place encrypted ballots.")]
     public string? OutDir { get; set; }
 


### PR DESCRIPTION
### Issue

Fixes #336 

### Description
Adds ability to specify which ballots should be spoiled in the CLI, also can specify a device file.

### Testing
Run CLI like:

```
encrypt
--context ...\context.json
--manifest ...\manifest.json
--ballots ...\plaintext_ballots_dir
--device ...\1237890000-1237890000
--spoiled_ids ballot-f53f9dd7-0f8e-11ed-a95e-04d9f5218a21,ballot-f53f9dd8-0f8e-11ed-ac4f-04d9f5218a21,ballot-f5417297-0f8e-11ed-a773-04d9f5218a21,ballot-60c7ba75-1e44-11ed-92f6-4c1d96f207af
--out G:\artifacts\encrypted_ballots
```